### PR TITLE
Optimize templates

### DIFF
--- a/contracts/pool-templates/DepositYLend.vy
+++ b/contracts/pool-templates/DepositYLend.vy
@@ -110,15 +110,17 @@ def add_liquidity(uamounts: uint256[N_COINS], min_mint_amount: uint256):
 
             # Mint if needed
             if use_lending[i]:
-                yERC20(self.coins[i]).deposit(uamount)
-                amounts[i] = ERC20(self.coins[i]).balanceOf(self)
+                _coin: address = self.coins[i]
+                yERC20(_coin).deposit(uamount)
+                amounts[i] = ERC20(_coin).balanceOf(self)
             else:
                 amounts[i] = uamount
 
     Curve(self.curve).add_liquidity(amounts, min_mint_amount)
 
-    tokens: uint256 = ERC20(self.token).balanceOf(self)
-    assert ERC20(self.token).transfer(msg.sender, tokens)
+    _token: address = self.token
+    tokens: uint256 = ERC20(_token).balanceOf(self)
+    assert ERC20(_token).transfer(msg.sender, tokens)
 
 
 @internal
@@ -245,7 +247,8 @@ def get_y(A: uint256, i: int128, _xp: uint256[N_COINS], D: uint256) -> uint256:
     """
     # x in the input is converted to the same price/precision
 
-    assert (i >= 0) and (i < N_COINS)
+    assert i >= 0
+    assert i < N_COINS
 
     c: uint256 = D
     S_: uint256 = 0

--- a/contracts/pool-templates/DepositYLend.vy
+++ b/contracts/pool-templates/DepositYLend.vy
@@ -196,8 +196,8 @@ def remove_liquidity_imbalance(uamounts: uint256[N_COINS], max_burn_amount: uint
     self._send_all(msg.sender, empty(uint256[N_COINS]), -1)
 
 
+@pure
 @internal
-@view
 def _xp_mem(rates: uint256[N_COINS], _balances: uint256[N_COINS]) -> uint256[N_COINS]:
     result: uint256[N_COINS] = rates
     for i in range(N_COINS):
@@ -205,8 +205,8 @@ def _xp_mem(rates: uint256[N_COINS], _balances: uint256[N_COINS]) -> uint256[N_C
     return result
 
 
+@pure
 @internal
-@view
 def get_D(A: uint256, xp: uint256[N_COINS]) -> uint256:
     S: uint256 = 0
     for _x in xp:
@@ -233,8 +233,8 @@ def get_D(A: uint256, xp: uint256[N_COINS]) -> uint256:
     return D
 
 
+@pure
 @internal
-@view
 def get_y(A: uint256, i: int128, _xp: uint256[N_COINS], D: uint256) -> uint256:
     """
     Calculate x[i] if one reduces D from being calculated for _xp to D
@@ -279,8 +279,8 @@ def get_y(A: uint256, i: int128, _xp: uint256[N_COINS], D: uint256) -> uint256:
     return y
 
 
-@internal
 @view
+@internal
 def _calc_withdraw_one_coin(_token_amount: uint256, i: int128, rates: uint256[N_COINS]) -> uint256:
     # First, need to calculate
     # * Get current D
@@ -326,8 +326,8 @@ def _calc_withdraw_one_coin(_token_amount: uint256, i: int128, rates: uint256[N_
     return dy
 
 
-@external
 @view
+@external
 def calc_withdraw_one_coin(_token_amount: uint256, i: int128) -> uint256:
     rates: uint256[N_COINS] = empty(uint256[N_COINS])
     use_lending: bool[N_COINS] = USE_LENDING

--- a/contracts/pool-templates/StableSwapYLend.vy
+++ b/contracts/pool-templates/StableSwapYLend.vy
@@ -155,6 +155,20 @@ def __init__(
     for i in range(N_COINS):
         assert _coins[i] != ZERO_ADDRESS
         assert _underlying_coins[i] != ZERO_ADDRESS
+
+        # approve underlying coins for infinite transfers
+        _response: Bytes[32] = raw_call(
+            _underlying_coins[i],
+            concat(
+                method_id("approve(address,uint256)"),
+                convert(_coins[i], bytes32),
+                convert(MAX_UINT256, bytes32),
+            ),
+            max_outsize=32,
+        )
+        if len(_response) > 0:
+            assert convert(_response, bool)
+
     self.coins = _coins
     self.underlying_coins = _underlying_coins
     self.initial_A = _A
@@ -518,18 +532,6 @@ def exchange_underlying(i: int128, j: int128, dx: uint256, min_dy: uint256):
             method_id("transferFrom(address,address,uint256)"),
             convert(msg.sender, bytes32),
             convert(self, bytes32),
-            convert(dx, bytes32),
-        ),
-        max_outsize=32,
-    )
-    if len(_response) > 0:
-        assert convert(_response, bool)
-
-    _response = raw_call(
-        self.underlying_coins[i],
-        concat(
-            method_id("approve(address,uint256)"),
-            convert(self.coins[i], bytes32),
             convert(dx, bytes32),
         ),
         max_outsize=32,


### PR DESCRIPTION
### What I did
* use memory variables to reduce the number of `SLOAD` operations
* approve coins and underlying coins for `MAX_UINT256` during deployment to avoid repeated approvals
* swap `@view` for `@pure` where applicable
