### PR TITLE
Make precisions consistent in get_dy* and exchange*

### DIFF
--- a/contracts/pool-templates/StableSwapBase.vy
+++ b/contracts/pool-templates/StableSwapBase.vy
@@ -401,9 +401,9 @@ def get_dy(i: int128, j: int128, dx: uint256) -> uint256:
 
     x: uint256 = xp[i] + (dx * rates[i] / PRECISION)
     y: uint256 = self.get_y(i, j, x, xp)
-    dy: uint256 = (xp[j] - y - 1) * PRECISION / rates[j]
+    dy: uint256 = (xp[j] - y - 1)
     _fee: uint256 = self.fee * dy / FEE_DENOMINATOR
-    return dy - _fee
+    return (dy - _fee) * PRECISION / rates[j]
 
 
 @external

--- a/contracts/pool-templates/StableSwapYLend.vy
+++ b/contracts/pool-templates/StableSwapYLend.vy
@@ -433,9 +433,9 @@ def get_dy(i: int128, j: int128, dx: uint256) -> uint256:
 
     x: uint256 = xp[i] + dx * rates[i] / PRECISION
     y: uint256 = self.get_y(i, j, x, xp)
-    dy: uint256 = (xp[j] - y) * PRECISION / rates[j]
+    dy: uint256 = xp[j] - y
     _fee: uint256 = self.fee * dy / FEE_DENOMINATOR
-    return dy - _fee
+    return (dy - _fee) * PRECISION / rates[j]
 
 
 @view
@@ -461,9 +461,9 @@ def get_dy_underlying(i: int128, j: int128, dx: uint256) -> uint256:
 
     x: uint256 = xp[i] + dx * precisions[i]
     y: uint256 = self.get_y(i, j, x, xp)
-    dy: uint256 = (xp[j] - y - 1) / precisions[j]
+    dy: uint256 = xp[j] - y - 1
     _fee: uint256 = self.fee * dy / FEE_DENOMINATOR
-    return dy - _fee
+    return (dy - _fee) / precisions[j]
 
 
 @external


### PR DESCRIPTION
`get_dy` and `get_dy_underlying` were inconsistent with `exchange` methods: rounding off was giving results different by 1 sometimes.

This PR fixes it