### PR TITLE
Deposit template updates and test cases

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -41,7 +41,7 @@ jobs:
       run: pip install -r requirements.txt
 
     - name: Run Tests
-      run: pytest tests/pools/common/unitary --pool ${{ matrix.pool }}
+      run: pytest tests/pools/common/unitary tests/zaps/common --pool ${{ matrix.pool }}
 
   integration:
     runs-on: ubuntu-latest

--- a/contracts/pool-templates/DepositYLend.vy
+++ b/contracts/pool-templates/DepositYLend.vy
@@ -20,6 +20,7 @@ interface Curve:
     def add_liquidity(amounts: uint256[N_COINS], min_mint_amount: uint256): nonpayable
     def remove_liquidity(_amount: uint256, min_amounts: uint256[N_COINS]): nonpayable
     def remove_liquidity_imbalance(amounts: uint256[N_COINS], max_burn_amount: uint256): nonpayable
+    def remove_liquidity_one_coin(_token_amount: uint256, i: int128, min_amount: uint256): nonpayable
     def balances(i: int128) -> uint256: view
     def A() -> uint256: view
     def fee() -> uint256: view
@@ -196,197 +197,39 @@ def remove_liquidity_imbalance(uamounts: uint256[N_COINS], max_burn_amount: uint
     self._send_all(msg.sender, empty(uint256[N_COINS]), -1)
 
 
-@pure
-@internal
-def _xp_mem(rates: uint256[N_COINS], _balances: uint256[N_COINS]) -> uint256[N_COINS]:
-    result: uint256[N_COINS] = rates
-    for i in range(N_COINS):
-        result[i] = result[i] * _balances[i] / PRECISION
-    return result
-
-
-@pure
-@internal
-def get_D(A: uint256, xp: uint256[N_COINS]) -> uint256:
-    S: uint256 = 0
-    for _x in xp:
-        S += _x
-    if S == 0:
-        return 0
-
-    Dprev: uint256 = 0
-    D: uint256 = S
-    Ann: uint256 = A * N_COINS
-    for _i in range(255):
-        D_P: uint256 = D
-        for _x in xp:
-            D_P = D_P * D / (_x * N_COINS + 1)  # +1 is to prevent /0
-        Dprev = D
-        D = (Ann * S + D_P * N_COINS) * D / ((Ann - 1) * D + (N_COINS + 1) * D_P)
-        # Equality with the precision of 1
-        if D > Dprev:
-            if D - Dprev <= 1:
-                break
-        else:
-            if Dprev - D <= 1:
-                break
-    return D
-
-
-@pure
-@internal
-def get_y(A: uint256, i: int128, _xp: uint256[N_COINS], D: uint256) -> uint256:
-    """
-    Calculate x[i] if one reduces D from being calculated for _xp to D
-
-    Done by solving quadratic equation iteratively.
-    x_1**2 + x1 * (sum' - (A*n**n - 1) * D / (A * n**n)) = D ** (n + 1) / (n ** (2 * n) * prod' * A)
-    x_1**2 + b*x_1 = c
-
-    x_1 = (x_1**2 + c) / (2*x_1 + b)
-    """
-    # x in the input is converted to the same price/precision
-
-    assert i >= 0
-    assert i < N_COINS
-
-    c: uint256 = D
-    S_: uint256 = 0
-    Ann: uint256 = A * N_COINS
-
-    _x: uint256 = 0
-    for _i in range(N_COINS):
-        if _i != i:
-            _x = _xp[_i]
-        else:
-            continue
-        S_ += _x
-        c = c * D / (_x * N_COINS)
-    c = c * D / (Ann * N_COINS)
-    b: uint256 = S_ + D / Ann
-    y_prev: uint256 = 0
-    y: uint256 = D
-    for _i in range(255):
-        y_prev = y
-        y = (y*y + c) / (2 * y + b - D)
-        # Equality with the precision of 1
-        if y > y_prev:
-            if y - y_prev <= 1:
-                break
-        else:
-            if y_prev - y <= 1:
-                break
-    return y
-
-
-@view
-@internal
-def _calc_withdraw_one_coin(_token_amount: uint256, i: int128, rates: uint256[N_COINS]) -> uint256:
-    # First, need to calculate
-    # * Get current D
-    # * Solve Eqn against y_i for D - _token_amount
-    use_lending: bool[N_COINS] = USE_LENDING
-    crv: address = self.curve
-    A: uint256 = Curve(crv).A()
-    fee: uint256 = Curve(crv).fee() * N_COINS / (4 * (N_COINS - 1))
-    fee += fee * FEE_IMPRECISION / FEE_DENOMINATOR  # Overcharge to account for imprecision
-    precisions: uint256[N_COINS] = PRECISION_MUL
-    total_supply: uint256 = ERC20(self.token).totalSupply()
-
-    xp: uint256[N_COINS] = PRECISION_MUL
-    S: uint256 = 0
-    for j in range(N_COINS):
-        xp[j] *= Curve(crv).balances(j)
-        if use_lending[j]:
-            # Use stored rate b/c we have imprecision anyway
-            xp[j] = xp[j] * rates[j] / LENDING_PRECISION
-        S += xp[j]
-        # if not use_lending - all good already
-
-    D0: uint256 = self.get_D(A, xp)
-    D1: uint256 = D0 - _token_amount * D0 / total_supply
-    xp_reduced: uint256[N_COINS] = xp
-
-    # xp = xp - fee * | xp * D1 / D0 - (xp - S * dD / D0 * (0, ... 1, ..0))|
-    for j in range(N_COINS):
-        dx_expected: uint256 = 0
-        b_ideal: uint256 = xp[j] * D1 / D0
-        b_expected: uint256 = xp[j]
-        if j == i:
-            b_expected -= S * (D0 - D1) / D0
-        if b_ideal >= b_expected:
-            dx_expected = (b_ideal - b_expected)
-        else:
-            dx_expected = (b_expected - b_ideal)
-        xp_reduced[j] -= fee * dx_expected / FEE_DENOMINATOR
-
-    dy: uint256 = xp_reduced[i] - self.get_y(A, i, xp_reduced, D1)
-    dy = dy / precisions[i]
-
-    return dy
-
-
-@view
-@external
-def calc_withdraw_one_coin(_token_amount: uint256, i: int128) -> uint256:
-    rates: uint256[N_COINS] = empty(uint256[N_COINS])
-    use_lending: bool[N_COINS] = USE_LENDING
-
-    for j in range(N_COINS):
-        if use_lending[j]:
-            rates[j] = yERC20(self.coins[j]).getPricePerFullShare()
-        else:
-            rates[j] = 10 ** 18
-
-    return self._calc_withdraw_one_coin(_token_amount, i, rates)
-
-
 @external
 @nonreentrant('lock')
 def remove_liquidity_one_coin(
     _token_amount: uint256,
     i: int128,
-    min_uamount: uint256,
-    donate_dust: bool = False
+    min_uamount: uint256
 ):
+
     """
     Remove _amount of liquidity all in a form of coin i
     """
-    use_lending: bool[N_COINS] = USE_LENDING
-    rates: uint256[N_COINS] = empty(uint256[N_COINS])
-    _token: address = self.token
-
-    for j in range(N_COINS):
-        if use_lending[j]:
-            rates[j] = yERC20(self.coins[j]).getPricePerFullShare()
-        else:
-            rates[j] = LENDING_PRECISION
-
-    dy: uint256 = self._calc_withdraw_one_coin(_token_amount, i, rates)
-    assert dy >= min_uamount, "Not enough coins removed"
-
     assert ERC20(self.token).transferFrom(msg.sender, self, _token_amount)
 
-    amounts: uint256[N_COINS] = empty(uint256[N_COINS])
-    amounts[i] = dy * LENDING_PRECISION / rates[i]
-    token_amount_before: uint256 = ERC20(_token).balanceOf(self)
-    Curve(self.curve).remove_liquidity_imbalance(amounts, _token_amount)
+    Curve(self.curve).remove_liquidity_one_coin(_token_amount, i, 0)
 
-    # Unwrap and transfer all the coins we've got
-    self._send_all(msg.sender, empty(uint256[N_COINS]), i)
+    use_lending: bool[N_COINS] = USE_LENDING
+    if use_lending[i]:
+        _coin: address = self.coins[i]
+        _balance: uint256 = ERC20(_coin).balanceOf(self)
+        yERC20(_coin).withdraw(_balance)
 
-    if not donate_dust:
-        # Transfer unused tokens back
-        token_amount_after: uint256 = ERC20(_token).balanceOf(self)
-        if token_amount_after > token_amount_before:
-            assert ERC20(_token).transfer(msg.sender, token_amount_after - token_amount_before)
+    _coin: address = self.underlying_coins[i]
+    _balance: uint256 = ERC20(_coin).balanceOf(self)
+    assert _balance >= min_uamount, "Not enough coins removed"
 
-
-@external
-@nonreentrant('lock')
-def withdraw_donated_dust():
-    owner: address = Curve(self.curve).owner()
-    assert msg.sender == owner
-
-    _token: address = self.token
-    assert ERC20(_token).transfer(owner, ERC20(_token).balanceOf(self))
+    _response: Bytes[32] = raw_call(
+        _coin,
+        concat(
+            method_id("transfer(address,uint256)"),
+            convert(msg.sender, bytes32),
+            convert(_balance, bytes32),
+        ),
+        max_outsize=32,
+    )
+    if len(_response) > 0:
+        assert convert(_response, bool)

--- a/tests/README.md
+++ b/tests/README.md
@@ -4,9 +4,10 @@ Test cases for Curve pools.
 
 ## Subdirectories
 
-* [`fixtures`](fixtures): Pytest fixtures](https://docs.pytest.org/en/latest/fixture.html)
+* [`fixtures`](fixtures): [Pytest fixtures](https://docs.pytest.org/en/latest/fixture.html)
 * [`pools`](pools): Tests for [pool](../contracts/pools) contracts
 * [`token`](token): Tests for [LP token](../contracts/tokens) contracts
+* [`zaps`](zaps): Tests for deposit contracts
 
 ## Files
 
@@ -16,7 +17,7 @@ Test cases for Curve pools.
 ## Organization
 
 * Tests are organized by general category, then split between unitary and integration tests.
-* Common tests for all pools are located in [`tests/common`](common).
+* Common tests for all pools are located in [`tests/pools/common`](pools/common), for zaps in [`tests/zaps/common`](zaps/common).
 * Valid pool names are the names of the subdirectories within [`contracts/pools`](../contracts/pools).
 
 ## Running the tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,8 @@ import pytest
 from brownie.project.main import get_loaded_projects
 from pathlib import Path
 
-from brownie_hooks import DECIMALS as hook_decimals
+from brownie_hooks import DECIMALS as hook_decimals, USE_LENDING as hook_lending
+
 
 # functions in wrapped methods are renamed to simplify common tests
 
@@ -73,8 +74,8 @@ def pytest_sessionstart():
         "lp_contract": lp_contract,
         "wrapped_contract": "yERC20",
         "coins": [
-            {"decimals": i, "tethered": bool(i), "wrapped": True, "wrapped_decimals": i}
-            for i in hook_decimals
+            {"decimals": d, "tethered": bool(d), "wrapped": w, "wrapped_decimals": d}
+            for d, w in zip(hook_decimals, hook_lending)
         ]
     }
     _pooldata['template-base'] = {
@@ -99,7 +100,7 @@ def pytest_generate_tests(metafunc):
                     params = metafunc.config.getoption("pool").split(',')
                 else:
                     params = list(_pooldata)
-                if test_path.parts[2] == "zaps":
+                if test_path.parts[1] == "zaps":
                     # for zap tests, filter by pools that have a Deposit contract
                     params = [i for i in params if _pooldata[i].get("zap_contract")]
             else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -124,11 +124,14 @@ def pytest_collection_modifyitems(config, items):
             continue
 
         # remove excess `itercoins` parametrized tests
-        if next(item.iter_markers(name="itercoins"), None):
-            values = [i for i in params.values() if isinstance(i, int)]
+        for marker in item.iter_markers(name="itercoins"):
+            values = [params[i] for i in marker.args]
             if max(values) >= len(data['coins']) or len(set(values)) < len(values):
                 items.remove(item)
-                continue
+                break
+
+        if item not in items:
+            continue
 
         # apply `skip_pool` marker
         for marker in item.iter_markers(name="skip_pool"):

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -33,6 +33,7 @@ All deployment fixtures are [parametrized](https://docs.pytest.org/en/stable/par
 * `swap`: [`StableSwap`](../../contracts/pool-templates) deployment for the pool being tested.
 * `underlying_coins`: A list of mocked token contracts representing the underlying coins in the active pool.
 * `wrapped_coins`: A list of mocked token contracts representing the wrapped coins in the active pool. The contract used is determined based on `pooldata.json` for the active pool. For pools without lending, these are the same deployments as `underlying_coins`.
+* `zap`: [`Deposit`](../../contracts/pool-templates) deployment for the pool being tested.
 
 ### `functions.py`
 
@@ -64,5 +65,6 @@ pytestmark = pytest.mark.usefixtures("add_initial_liquidity", "mint_bob")
 * `add_initial_liquidity`: Mints and approves `initial_amounts` coins for `alice` and adds them to `swap` to provide initial liquidity.
 * `approve_alice`: Approves `swap` for unlimited transfers of all underlying and wrapped coins from `alice`.
 * `approve_bob`:Approves `swap` for unlimited transfers of all underlying and wrapped coins from `bob`.
+* `approve_zap`: Approves `zap` for unlimited transfers of `pool_token` and all coins and from `alice` and `bob`.
 * `mint_alice`: Mints `initial_amounts` of each underlying and wrapped coin for `alice`.
 * `mint_bob`: Mints `initial_amounts` of each underlying and wrapped coin for `bob`.

--- a/tests/fixtures/deployments.py
+++ b/tests/fixtures/deployments.py
@@ -49,7 +49,6 @@ def pool_token(project, alice, pool_data):
 
 
 @pytest.fixture(scope="module")
-@pytest.mark.parametrize()
 def swap(project, alice, underlying_coins, wrapped_coins, pool_token, pool_data):
     deployer = getattr(project, pool_data['swap_contract'])
 
@@ -70,6 +69,12 @@ def swap(project, alice, underlying_coins, wrapped_coins, pool_token, pool_data)
     pool_token.set_minter(contract, {'from': alice})
 
     yield contract
+
+
+@pytest.fixture(scope="module")
+def zap(project, alice, swap, underlying_coins, wrapped_coins, pool_token, pool_data):
+    deployer = getattr(project, pool_data['zap_contract'])
+    yield deployer.deploy(wrapped_coins, underlying_coins, swap, pool_token, {'from': alice})
 
 
 @pytest.fixture(scope="module")

--- a/tests/fixtures/setup.py
+++ b/tests/fixtures/setup.py
@@ -3,7 +3,7 @@ import pytest
 
 @pytest.fixture(scope="module")
 def add_initial_liquidity(alice, mint_alice, approve_alice, underlying_coins, swap, initial_amounts):
-    # mint (10**6 * precision) of each coin in the pool
+    # mint (10**7 * precision) of each coin in the pool
     eth_value = 0
     if "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE" in underlying_coins:
         eth_value = 10 ** 24
@@ -57,3 +57,15 @@ def approve_alice(alice, underlying_coins, wrapped_coins, swap, initial_amounts)
         underlying.approve(swap, 2**256-1, {'from': alice})
         if underlying != wrapped:
             wrapped.approve(swap, 2**256-1, {'from': alice})
+
+
+@pytest.fixture(scope="module")
+def approve_zap(alice, bob, zap, pool_token, underlying_coins, initial_amounts):
+    for underlying, amount in zip(underlying_coins, initial_amounts):
+        if underlying == "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE":
+            continue
+        underlying.approve(zap, 2**256-1, {'from': alice})
+        underlying.approve(zap, 2**256-1, {'from': bob})
+
+    pool_token.approve(zap, 2**256-1, {'from': alice})
+    pool_token.approve(zap, 2**256-1, {'from': bob})

--- a/tests/zaps/common/test_add_liquidity_initial_zap.py
+++ b/tests/zaps/common/test_add_liquidity_initial_zap.py
@@ -1,0 +1,49 @@
+import brownie
+import pytest
+
+pytestmark = pytest.mark.usefixtures("mint_alice", "approve_zap")
+
+
+@pytest.mark.parametrize("min_amount", (False, True))
+def test_initial(
+    alice,
+    zap,
+    swap,
+    underlying_coins,
+    wrapped_coins,
+    pool_token,
+    underlying_decimals,
+    n_coins,
+    initial_amounts,
+    min_amount,
+):
+    amounts = [10**i for i in underlying_decimals]
+    min_amount = 10**18 * n_coins if min_amount else 0
+
+    zap.add_liquidity(amounts, min_amount, {'from': alice})
+
+    zipped = zip(underlying_coins, wrapped_coins, amounts, initial_amounts)
+    for underlying, wrapped, amount, initial in zipped:
+        assert underlying.balanceOf(alice) == initial - amount
+
+        if wrapped == underlying:
+            assert underlying.balanceOf(zap) == 0
+            assert underlying.balanceOf(swap) == amount
+        else:
+            assert underlying.balanceOf(zap) == 0
+            assert underlying.balanceOf(swap) == 0
+            assert wrapped.balanceOf(alice) == initial
+            assert wrapped.balanceOf(zap) == 0
+            assert wrapped.balanceOf(swap) == amount
+
+    assert pool_token.balanceOf(alice) == n_coins * 10**18
+    assert pool_token.totalSupply() == n_coins * 10**18
+
+
+@pytest.mark.itercoins("idx")
+def test_initial_liquidity_missing_coin(alice, zap, pool_token, idx, underlying_decimals):
+    amounts = [10**i for i in underlying_decimals]
+    amounts[idx] = 0
+
+    with brownie.reverts():
+        zap.add_liquidity(amounts, 0, {'from': alice})

--- a/tests/zaps/common/test_add_liquidity_zap.py
+++ b/tests/zaps/common/test_add_liquidity_zap.py
@@ -1,0 +1,84 @@
+import brownie
+import pytest
+
+pytestmark = pytest.mark.usefixtures("add_initial_liquidity", "mint_bob", "approve_zap")
+
+
+def test_add_liquidity(bob, zap, swap, underlying_coins, wrapped_coins, pool_token, initial_amounts, n_coins):
+    zap.add_liquidity(initial_amounts, 0, {'from': bob})
+
+    for wrapped, underlying, amount in zip(wrapped_coins, underlying_coins, initial_amounts):
+        assert underlying.balanceOf(bob) == 0
+
+        if wrapped == underlying:
+            assert underlying.balanceOf(zap) == 0
+            assert underlying.balanceOf(swap) == amount * 2
+        else:
+            assert underlying.balanceOf(zap) == 0
+            assert underlying.balanceOf(swap) == 0
+            assert wrapped.balanceOf(bob) == amount
+            assert wrapped.balanceOf(zap) == 0
+            assert wrapped.balanceOf(swap) == amount * 2
+
+    assert pool_token.balanceOf(bob) == n_coins * 10**24
+    assert pool_token.totalSupply() == n_coins * 10**24 * 2
+
+
+def test_add_liquidity_with_slippage(bob, zap, pool_token, underlying_coins, underlying_decimals, n_coins):
+    amounts = [10**i for i in underlying_decimals]
+    amounts[0] = int(amounts[0] * 0.99)
+    amounts[1] = int(amounts[1] * 1.01)
+    zap.add_liquidity(amounts, 0, {'from': bob})
+
+    for coin in underlying_coins:
+        assert coin.balanceOf(zap) == 0
+
+    assert 0.999 < pool_token.balanceOf(bob) / (n_coins * 10**18) < 1
+    assert pool_token.balanceOf(zap) == 0
+
+
+@pytest.mark.itercoins("idx")
+def test_add_one_coin(bob, swap, zap, underlying_coins, wrapped_coins, pool_token, initial_amounts, idx, n_coins):
+    amounts = [0] * n_coins
+    amounts[idx] = initial_amounts[idx]
+    zap.add_liquidity(amounts, 0, {'from': bob})
+
+    zipped = zip(underlying_coins, wrapped_coins, amounts, initial_amounts)
+    for underlying, wrapped, amount, initial in zipped:
+        assert underlying.balanceOf(bob) == initial - amount
+
+        if wrapped == underlying:
+            assert underlying.balanceOf(zap) == 0
+            assert underlying.balanceOf(swap) == amount + initial
+        else:
+            assert underlying.balanceOf(zap) == 0
+            assert underlying.balanceOf(swap) == 0
+            assert wrapped.balanceOf(bob) == initial
+            assert wrapped.balanceOf(zap) == 0
+            assert wrapped.balanceOf(swap) == amount + initial
+
+    assert 0.999 < pool_token.balanceOf(bob) / 10**24 < 1
+    assert pool_token.balanceOf(zap) == 0
+
+
+def test_insufficient_balance(charlie, zap, underlying_decimals):
+    amounts = [(10**i) for i in underlying_decimals]
+    with brownie.reverts():
+        zap.add_liquidity(amounts, 0, {'from': charlie})
+
+
+@pytest.mark.parametrize("min_amount", [False, True])
+def test_min_amount_too_high(alice, zap, underlying_decimals, min_amount, n_coins):
+
+    amounts = [10**i for i in underlying_decimals]
+    min_amount = n_coins * 10**18 + 1 if min_amount else 2**256 - 1
+    with brownie.reverts():
+        zap.add_liquidity(amounts, min_amount, {'from': alice})
+
+
+def test_min_amount_with_slippage(bob, zap, underlying_decimals, n_coins):
+    amounts = [10**i for i in underlying_decimals]
+    amounts[0] = int(amounts[0] * 0.99)
+    amounts[1] = int(amounts[1] * 1.01)
+    with brownie.reverts():
+        zap.add_liquidity(amounts, n_coins * 10**18, {'from': bob})

--- a/tests/zaps/common/test_remove_liquidity_imbalance_zap.py
+++ b/tests/zaps/common/test_remove_liquidity_imbalance_zap.py
@@ -1,0 +1,61 @@
+import pytest
+
+pytestmark = pytest.mark.usefixtures("add_initial_liquidity", "approve_zap")
+
+
+@pytest.mark.itercoins("idx")
+@pytest.mark.parametrize("divisor", [10, 50, 100])
+def test_remove_imbalance(
+    alice,
+    bob,
+    swap,
+    zap,
+    underlying_coins,
+    wrapped_coins,
+    pool_token,
+    idx,
+    n_coins,
+    initial_amounts,
+    divisor,
+):
+    amounts = [i // divisor for i in initial_amounts]
+    max_burn = (n_coins * 10**24) // divisor
+
+    pool_token.transfer(bob, pool_token.balanceOf(alice), {'from': alice})
+    zap.remove_liquidity_imbalance(amounts, max_burn + 1, {'from': bob})
+
+    zipped = zip(underlying_coins, wrapped_coins, initial_amounts, amounts)
+    for underlying, wrapped, initial, expected in zipped:
+        assert underlying.balanceOf(zap) == 0
+        assert wrapped.balanceOf(zap) == 0
+
+        assert 0 < underlying.balanceOf(bob) <= expected
+        assert wrapped.balanceOf(swap) == initial - expected
+
+    assert abs(pool_token.balanceOf(bob) - (n_coins * 10**24 - max_burn)) <= 1
+    assert pool_token.balanceOf(zap) == 0
+
+
+@pytest.mark.itercoins("idx")
+def test_remove_some(
+    alice, bob, swap, zap, underlying_coins, wrapped_coins, pool_token, idx, initial_amounts
+):
+    amounts = [i//2 for i in initial_amounts]
+    amounts[idx] = 0
+
+    pool_token.transfer(bob, pool_token.balanceOf(alice), {'from': alice})
+    zap.remove_liquidity_imbalance(amounts, 2**256-1, {'from': bob})
+
+    zipped = zip(underlying_coins, wrapped_coins, initial_amounts, amounts)
+    for underlying, wrapped, initial, expected in zipped:
+        assert underlying.balanceOf(zap) == 0
+        assert wrapped.balanceOf(zap) == 0
+
+        if expected:
+            assert 0 < underlying.balanceOf(bob) <= expected
+            assert wrapped.balanceOf(swap) == initial - expected
+        else:
+            assert underlying.balanceOf(bob) == 0
+            assert wrapped.balanceOf(swap) == initial
+
+    assert pool_token.balanceOf(zap) == 0

--- a/tests/zaps/common/test_remove_liquidity_one_coin_zap.py
+++ b/tests/zaps/common/test_remove_liquidity_one_coin_zap.py
@@ -1,0 +1,38 @@
+import brownie
+import pytest
+
+# old deployments are skipped because of a known issue with dust
+
+pytestmark = [
+    pytest.mark.usefixtures("add_initial_liquidity", "approve_zap"),
+    pytest.mark.skip_pool("busd", "compound", "pax", "susd", "usdt", "y")
+]
+
+
+@pytest.mark.itercoins("idx")
+@pytest.mark.parametrize("divisor", [10, 50, 100])
+def test_remove_one(alice, bob, zap, underlying_coins, wrapped_coins, pool_token, idx, divisor):
+    underlying = underlying_coins[idx]
+    wrapped = wrapped_coins[idx]
+
+    initial_amount = pool_token.balanceOf(alice)
+    amount = initial_amount // divisor
+
+    pool_token.transfer(bob, initial_amount, {'from': alice})
+    zap.remove_liquidity_one_coin(amount, idx, 0, {'from': bob})
+
+    assert underlying.balanceOf(zap) == 0
+    assert wrapped.balanceOf(zap) == 0
+    assert pool_token.balanceOf(zap) == 0
+
+    if wrapped != underlying:
+        assert wrapped.balanceOf(bob) == 0
+
+    assert pool_token.balanceOf(bob) == initial_amount - amount
+    assert 0 < underlying.balanceOf(bob) <= amount
+
+
+@pytest.mark.itercoins("idx")
+def test_amount_exceeds_balance(bob, zap, idx):
+    with brownie.reverts():
+        zap.remove_liquidity_one_coin(1, idx, 0, {'from': bob})

--- a/tests/zaps/common/test_remove_liquidity_zap.py
+++ b/tests/zaps/common/test_remove_liquidity_zap.py
@@ -1,0 +1,64 @@
+import brownie
+import pytest
+
+pytestmark = pytest.mark.usefixtures("add_initial_liquidity", "approve_zap")
+
+
+def test_remove_liquidity(
+    alice,
+    bob,
+    swap,
+    zap,
+    underlying_coins,
+    wrapped_coins,
+    pool_token,
+    initial_amounts,
+    n_coins,
+):
+    pool_token.transfer(bob, pool_token.balanceOf(alice), {'from': alice})
+    zap.remove_liquidity(n_coins * 10**24, [0] * n_coins, {'from': bob})
+
+    zipped = zip(underlying_coins, wrapped_coins, initial_amounts)
+    for underlying, wrapped, amount in zipped:
+        assert underlying.balanceOf(zap) == 0
+        assert wrapped.balanceOf(zap) == 0
+
+        assert underlying.balanceOf(swap) == 0
+        assert wrapped.balanceOf(swap) == 0
+        assert 0 < underlying.balanceOf(bob) <= amount
+
+    assert pool_token.balanceOf(bob) == 0
+    assert pool_token.totalSupply() == 0
+
+
+def test_remove_partial(
+    alice, bob, swap, zap, underlying_coins, wrapped_coins, pool_token, initial_amounts, n_coins
+):
+    withdraw_amount = pool_token.balanceOf(alice) // 2
+    pool_token.transfer(bob, pool_token.balanceOf(alice), {'from': alice})
+    zap.remove_liquidity(withdraw_amount, [0] * n_coins, {'from': bob})
+
+    for underlying, wrapped, amount in zip(underlying_coins, wrapped_coins, initial_amounts):
+        assert underlying.balanceOf(zap) == 0
+        assert wrapped.balanceOf(zap) == 0
+
+        assert wrapped.balanceOf(swap) == amount // 2
+        assert 0 < underlying.balanceOf(bob) <= amount // 2
+
+    assert pool_token.balanceOf(zap) == 0
+    assert pool_token.balanceOf(bob) == n_coins * 10**24 - withdraw_amount
+    assert pool_token.totalSupply() == n_coins * 10**24 - withdraw_amount
+
+
+@pytest.mark.itercoins("idx")
+def test_below_min_amount(alice, zap, initial_amounts, n_coins, idx):
+    min_amount = initial_amounts.copy()
+    min_amount[idx] += 1
+
+    with brownie.reverts():
+        zap.remove_liquidity(n_coins * 10**24, min_amount, {'from': alice})
+
+
+def test_amount_exceeds_balance(alice, zap, n_coins):
+    with brownie.reverts():
+        zap.remove_liquidity(n_coins * 10**24 + 1, [0] * n_coins, {'from': alice})

--- a/tests/zaps/common/test_return_values.py
+++ b/tests/zaps/common/test_return_values.py
@@ -1,0 +1,35 @@
+import pytest
+
+pytestmark = [
+    pytest.mark.skip_pool("busd", "compound", "pax", "susd", "usdt", "y"),
+    pytest.mark.usefixtures("add_initial_liquidity", "approve_zap"),
+]
+
+
+def test_remove_liquidity(alice, bob, zap, initial_amounts, pool_token, n_coins, underlying_coins):
+    pool_token.transfer(bob, pool_token.balanceOf(alice), {'from': alice})
+    tx = zap.remove_liquidity(n_coins * 10**24 // 3, [0] * n_coins, {'from': bob})
+    for coin, expected_amount in zip(underlying_coins, tx.return_value):
+        assert coin.balanceOf(bob) == expected_amount
+
+
+def test_remove_imbalance(alice, bob, zap, initial_amounts, pool_token, underlying_coins):
+    amounts = [i//2 for i in initial_amounts]
+    amounts[0] = 0
+
+    pool_token.transfer(bob, pool_token.balanceOf(alice), {'from': alice})
+    tx = zap.remove_liquidity_imbalance(amounts, 2**256-1, {'from': bob})
+    for coin, expected_amount in zip(underlying_coins, tx.return_value):
+        assert coin.balanceOf(bob) == expected_amount
+
+
+def test_remove_one(alice, bob, zap, underlying_coins, wrapped_coins, pool_token):
+    pool_token.transfer(bob, pool_token.balanceOf(alice), {'from': alice})
+    tx = zap.remove_liquidity_one_coin(10**21, 1, 0, {'from': bob})
+
+    assert tx.return_value == underlying_coins[1].balanceOf(bob)
+
+
+def test_add_liquidity(bob, zap, initial_amounts, pool_token, mint_bob):
+    tx = zap.add_liquidity(initial_amounts, 0, {'from': bob})
+    assert pool_token.balanceOf(bob) == tx.return_value


### PR DESCRIPTION
### What I did
* update the Deposit template
* add generalized zap tests

### How I did it
#### `contracts/pool-templates/DepositYLend.vy`
* Removed the logic for calculating the expected withdrawal amount when calling `remove_liquidity_one_coin` - this is handled directly in the swap contract now, so by removing it we make withdrawals cheaper and less complex.
* Deposit and withdrawal functions now return a `uint256`, or array of `uint256`, relating to the amount of coins deposited/withdrawn. This allows us to call them as view methods and learn the result of a deposit/withdrawal prior to actually executing it. This is useful for the upcoming vault pool where we sometimes have to deal with withdrawal fees.
* Added natspec and standardized some variable names

#### `tests/`
* Added generalized deposit contract tests at `tests/zaps` - these are parametrized in the same way as pool tests, but only for pools that contain a deposit contract
* Added new fixtures for testing zaps
* Expanded test documentation
* Updated CI to run zap tests

### How to verify it
* Run the tests
* Verify the CI is passing