### PR TITLE
Snow pool

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,6 +4,7 @@ name: main workflow
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  NODE_OPTIONS: --max_old_space_size=4096
 
 jobs:
 
@@ -13,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pool: [3pool, busd, compound, hbtc, pax, ren, sbtc, susd, template-base, template-y, usdt, y]
+        pool: [3pool, busd, compound, hbtc, pax, ren, sbtc, snow, susd, template-base, template-y, usdt, y]
 
     steps:
     - uses: actions/checkout@v1
@@ -49,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pool: [3pool, busd, compound, hbtc, pax, ren, sbtc, susd, template-base, template-y, usdt, y]
+        pool: [3pool, busd, compound, hbtc, pax, ren, sbtc, snow, susd, template-base, template-y, usdt, y]
 
     steps:
     - uses: actions/checkout@v1

--- a/contracts/pools/README.md
+++ b/contracts/pools/README.md
@@ -12,6 +12,7 @@ Each subdirectory holds contracts and other files specific to a single Curve poo
 * [`pax`](pax): [PAX pool](https://www.curve.fi/pax), with lending on [yearn.finance](https://yearn.finance/)
 * [`ren`](ren): [RenBTC pool](https://www.curve.fi/ren)
 * [`sbtc`](sbtc): [sBTC pool](https://www.curve.fi/sbtc)
+* [`snow`](snow): [Snow pool](https://www.curve.fi/snow), for swaps between [yVault](https://feel-the-yearn.app/vaults) tokens
 * [`susd`](susd): [sUSD pool](https://www.curve.fi/susdv2)
 * [`usdt`](usdt): [USDT pool](https://www.curve.fi/usdt), with lending on [Compound](https://compound.finance/)
 * [`y`](y): [Y pool](https://www.curve.fi/y), with lending on [yearn.finance](https://yearn.finance/)

--- a/contracts/pools/snow/DepositSnow.vy
+++ b/contracts/pools/snow/DepositSnow.vy
@@ -1,11 +1,8 @@
-# @version ^0.2.0
+# @version 0.2.4
 """
-@title "Zap" Depositer for Yearn-style lending tokens
+@title "Zap" Depositer for Curve Snow pool
 @author Curve.Fi
 @license Copyright (c) Curve.Fi, 2020 - all rights reserved
-@notice deposit/withdraw Curve contract without too many transactions
-@dev This contract is only a template, pool-specific constants
-     must be set prior to compiling
 """
 
 from vyper.interfaces import ERC20

--- a/contracts/pools/snow/DepositSnow.vy
+++ b/contracts/pools/snow/DepositSnow.vy
@@ -1,0 +1,279 @@
+# @version ^0.2.0
+"""
+@title "Zap" Depositer for Yearn-style lending tokens
+@author Curve.Fi
+@license Copyright (c) Curve.Fi, 2020 - all rights reserved
+@notice deposit/withdraw Curve contract without too many transactions
+@dev This contract is only a template, pool-specific constants
+     must be set prior to compiling
+"""
+
+from vyper.interfaces import ERC20
+
+# External Contracts
+interface yERC20:
+    def deposit(depositAmount: uint256): nonpayable
+    def withdraw(withdrawTokens: uint256): nonpayable
+    def getPricePerFullShare() -> uint256: view
+
+interface Curve:
+    def add_liquidity(amounts: uint256[N_COINS], min_mint_amount: uint256): nonpayable
+    def remove_liquidity(_amount: uint256, min_amounts: uint256[N_COINS]): nonpayable
+    def remove_liquidity_imbalance(amounts: uint256[N_COINS], max_burn_amount: uint256): nonpayable
+    def remove_liquidity_one_coin(_token_amount: uint256, i: int128, min_amount: uint256): nonpayable
+    def balances(i: int128) -> uint256: view
+    def A() -> uint256: view
+    def fee() -> uint256: view
+    def owner() -> address: view
+
+
+# These constants must be set prior to compiling
+N_COINS: constant(int128) = 6
+PRECISION_MUL: constant(uint256[N_COINS]) = [1, 1000000000000, 1000000000000, 1, 1, 1000000000000]
+USE_LENDING: constant(bool[N_COINS]) = [True, True, True, True, True, False]
+
+# Fixed constants
+LENDING_PRECISION: constant(uint256) = 10 ** 18
+PRECISION: constant(uint256) = 10 ** 18
+FEE_DENOMINATOR: constant(uint256) = 10 ** 10
+FEE_IMPRECISION: constant(uint256) = 25 * 10 ** 8  # % of the fee
+
+coins: public(address[N_COINS])
+underlying_coins: public(address[N_COINS])
+curve: public(address)
+token: public(address)
+
+
+@external
+def __init__(
+    _coins: address[N_COINS],
+    _underlying_coins: address[N_COINS],
+    _curve: address,
+    _token: address
+):
+    """
+    @notice Contract constructor
+    @dev Where a token does not use wrapping, use the same address
+         for `_coins` and `_underlying_coins`
+    @param _coins List of wrapped coin addresses
+    @param _underlying_coins List of underlying coin addresses
+    @param _curve Pool address
+    @param _token Pool LP token address
+    """
+    for i in range(N_COINS):
+        assert _coins[i] != ZERO_ADDRESS
+        assert _underlying_coins[i] != ZERO_ADDRESS
+
+        # approve underlying and wrapped coins for infinite transfers
+        _response: Bytes[32] = raw_call(
+            _underlying_coins[i],
+            concat(
+                method_id("approve(address,uint256)"),
+                convert(_coins[i], bytes32),
+                convert(MAX_UINT256, bytes32),
+            ),
+            max_outsize=32,
+        )
+        if len(_response) > 0:
+            assert convert(_response, bool)
+        _response = raw_call(
+            _coins[i],
+            concat(
+                method_id("approve(address,uint256)"),
+                convert(_curve, bytes32),
+                convert(MAX_UINT256, bytes32),
+            ),
+            max_outsize=32,
+        )
+        if len(_response) > 0:
+            assert convert(_response, bool)
+
+    self.coins = _coins
+    self.underlying_coins = _underlying_coins
+    self.curve = _curve
+    self.token = _token
+
+
+@external
+@nonreentrant('lock')
+def add_liquidity(_underlying_amounts: uint256[N_COINS], _min_mint_amount: uint256) -> uint256:
+    """
+    @notice Wrap underlying coins and deposit them in the pool
+    @param _underlying_amounts List of amounts of underlying coins to deposit
+    @param _min_mint_amount Minimum amount of LP tokens to mint from the deposit
+    @return Amount of LP tokens received by depositing
+    """
+    use_lending: bool[N_COINS] = USE_LENDING
+    _wrapped_amounts: uint256[N_COINS] = empty(uint256[N_COINS])
+
+    for i in range(N_COINS):
+        _amount: uint256 = _underlying_amounts[i]
+
+        if _amount != 0:
+            # Transfer the underlying coin from owner
+            _response: Bytes[32] = raw_call(
+                self.underlying_coins[i],
+                concat(
+                    method_id("transferFrom(address,address,uint256)"),
+                    convert(msg.sender, bytes32),
+                    convert(self, bytes32),
+                    convert(_amount, bytes32)
+                ),
+                max_outsize=32
+            )
+            if len(_response) > 0:
+                assert convert(_response, bool)
+
+            # Mint if needed
+            if use_lending[i]:
+                _coin: address = self.coins[i]
+                yERC20(_coin).deposit(_amount)
+                _wrapped_amounts[i] = ERC20(_coin).balanceOf(self)
+            else:
+                _wrapped_amounts[i] = _amount
+
+    Curve(self.curve).add_liquidity(_wrapped_amounts, _min_mint_amount)
+
+    _lp_token: address = self.token
+    _lp_amount: uint256 = ERC20(_lp_token).balanceOf(self)
+    assert ERC20(_lp_token).transfer(msg.sender, _lp_amount)
+
+    return _lp_amount
+
+
+@internal
+def _unwrap_and_transfer(_addr: address, _min_amounts: uint256[N_COINS]) -> uint256[N_COINS]:
+    # unwrap coins and transfer them to the sender
+    use_lending: bool[N_COINS] = USE_LENDING
+    _amounts: uint256[N_COINS] = empty(uint256[N_COINS])
+
+    for i in range(N_COINS):
+        if use_lending[i]:
+            _coin: address = self.coins[i]
+            _balance: uint256 = ERC20(_coin).balanceOf(self)
+            if _balance == 0:  # Do nothing if there are 0 coins
+                continue
+            yERC20(_coin).withdraw(_balance)
+
+        _ucoin: address = self.underlying_coins[i]
+        _uamount: uint256 = ERC20(_ucoin).balanceOf(self)
+        assert _uamount >= _min_amounts[i], "Not enough coins withdrawn"
+
+        # Send only if we have something to send
+        if _uamount != 0:
+            _response: Bytes[32] = raw_call(
+                _ucoin,
+                concat(
+                    method_id("transfer(address,uint256)"),
+                    convert(_addr, bytes32),
+                    convert(_uamount, bytes32)
+                ),
+                max_outsize=32
+            )
+            if len(_response) > 0:
+                assert convert(_response, bool)
+            _amounts[i] = _uamount
+
+    return _amounts
+
+@external
+@nonreentrant('lock')
+def remove_liquidity(
+    _amount: uint256,
+    _min_underlying_amounts: uint256[N_COINS]
+) -> uint256[N_COINS]:
+    """
+    @notice Withdraw and unwrap coins from the pool
+    @dev Withdrawal amounts are based on current deposit ratios
+    @param _amount Quantity of LP tokens to burn in the withdrawal
+    @param _min_underlying_amounts Minimum amounts of underlying coins to receive
+    @return List of amounts of underlying coins that were withdrawn
+    """
+    assert ERC20(self.token).transferFrom(msg.sender, self, _amount)
+    Curve(self.curve).remove_liquidity(_amount, empty(uint256[N_COINS]))
+
+    return self._unwrap_and_transfer(msg.sender, _min_underlying_amounts)
+
+
+@external
+@nonreentrant('lock')
+def remove_liquidity_imbalance(
+    _underlying_amounts: uint256[N_COINS],
+    _max_burn_amount: uint256
+) -> uint256[N_COINS]:
+    """
+    @notice Withdraw and unwrap coins from the pool in an imbalanced amount
+    @dev Amounts in `_underlying_amounts` correspond to withdrawn amounts
+         before any fees charge for unwrapping.
+    @param _underlying_amounts List of amounts of underlying coins to withdraw
+    @param _max_burn_amount Maximum amount of LP token to burn in the withdrawal
+    @return List of amounts of underlying coins that were withdrawn
+    """
+    use_lending: bool[N_COINS] = USE_LENDING
+    _token: address = self.token
+
+    amounts: uint256[N_COINS] = _underlying_amounts
+    for i in range(N_COINS):
+        if use_lending[i] and amounts[i] > 0:
+            rate: uint256 = yERC20(self.coins[i]).getPricePerFullShare()
+            amounts[i] = amounts[i] * LENDING_PRECISION / rate
+        # if not use_lending - all good already
+
+    # Transfer max tokens in
+    _lp_amount: uint256 = ERC20(_token).balanceOf(msg.sender)
+    if _lp_amount > _max_burn_amount:
+        _lp_amount = _max_burn_amount
+    assert ERC20(_token).transferFrom(msg.sender, self, _lp_amount)
+
+    Curve(self.curve).remove_liquidity_imbalance(amounts, _max_burn_amount)
+
+    # Transfer unused LP tokens back
+    _lp_amount = ERC20(_token).balanceOf(self)
+    if _lp_amount != 0:
+        assert ERC20(_token).transfer(msg.sender, _lp_amount)
+
+    # Unwrap and transfer all the coins we've got
+    return self._unwrap_and_transfer(msg.sender, empty(uint256[N_COINS]))
+
+
+@external
+@nonreentrant('lock')
+def remove_liquidity_one_coin(
+    _amount: uint256,
+    i: int128,
+    _min_underlying_amount: uint256
+) -> uint256:
+    """
+    @notice Withdraw and unwrap a single coin from the pool
+    @param _amount Amount of LP tokens to burn in the withdrawal
+    @param i Index value of the coin to withdraw
+    @param _min_underlying_amount Minimum amount of underlying coin to receive
+    @return Amount of underlying coin received
+    """
+    assert ERC20(self.token).transferFrom(msg.sender, self, _amount)
+
+    Curve(self.curve).remove_liquidity_one_coin(_amount, i, 0)
+
+    use_lending: bool[N_COINS] = USE_LENDING
+    if use_lending[i]:
+        _coin: address = self.coins[i]
+        _balance: uint256 = ERC20(_coin).balanceOf(self)
+        yERC20(_coin).withdraw(_balance)
+
+    _coin: address = self.underlying_coins[i]
+    _balance: uint256 = ERC20(_coin).balanceOf(self)
+    assert _balance >= _min_underlying_amount, "Not enough coins removed"
+
+    _response: Bytes[32] = raw_call(
+        _coin,
+        concat(
+            method_id("transfer(address,uint256)"),
+            convert(msg.sender, bytes32),
+            convert(_balance, bytes32),
+        ),
+        max_outsize=32,
+    )
+    if len(_response) > 0:
+        assert convert(_response, bool)
+
+    return _balance

--- a/contracts/pools/snow/DepositSnow.vy
+++ b/contracts/pools/snow/DepositSnow.vy
@@ -134,7 +134,9 @@ def _unwrap_and_transfer(_addr: address, _min_amounts: uint256[N_COINS]) -> uint
     # unwrap coins and transfer them to the sender
     _amounts: uint256[N_COINS] = empty(uint256[N_COINS])
 
-    for i in range(N_COINS):
+    for x in range(N_COINS):
+        # we iterate backwards so that USDC is handled before unwrapping yvUSDC into USDC
+        i: int128 = N_COINS - 1 - x
         if i < 5:
             # only self.coins[5] is not wrapped
             _coin: address = self.coins[i]
@@ -163,6 +165,7 @@ def _unwrap_and_transfer(_addr: address, _min_amounts: uint256[N_COINS]) -> uint
             _amounts[i] = _uamount
 
     return _amounts
+
 
 @external
 @nonreentrant('lock')

--- a/contracts/pools/snow/README.md
+++ b/contracts/pools/snow/README.md
@@ -1,6 +1,6 @@
 # curve-contract/contracts/pools/y
 
-[Curve "Snow" pool](https://www.curve.fi/y), for efficient swaps of [yVault](https://feel-the-yearn.app/vaults) tokens ❄️
+[Curve "Snow" pool](https://www.curve.fi/y), for efficient swaps of [yVault](https://feel-the-yearn.app/vaults) tokens ☃️
 
 ## Contracts
 
@@ -8,15 +8,15 @@
 * [`StableSwapSnow`](StableSwapSnow.vy): Curve stablecoin AMM contract
 
 ## Deployments
-<!--
-* [`CurveContractV2`](../../tokens/CurveTokenV2.vy): []()
-* [`DepositSnow`](DepositSnow.vy): []()
-* [`StableSwapSnow`](StableSwapSnow.vy): []() -->
+* [`CurveContractV2`](../../tokens/CurveTokenV2.vy): [0x3921574E4146fC09701a1B24CFb0f9906e8FEe92](https://etherscan.io/address/0x3921574e4146fc09701a1b24cfb0f9906e8fee92)
+* [`DepositSnow`](DepositSnow.vy): [0x2021a9990640c8ff8FcCb553648571D525B53a6e](https://etherscan.io/address/0x2021a9990640c8ff8fccb553648571d525b53a6e)
+* [`LiquidityGauge`](../../gauges/LiquidityGauge.vy): [0x18478F737d40ed7DEFe5a9d6F1560d84E283B74e](https://etherscan.io/address/0x18478f737d40ed7defe5a9d6f1560d84e283b74e)
+* [`StableSwapSnow`](StableSwapSnow.vy): [0xF0f745C81E4533c697cF0104c5EFdCbf84359542](https://etherscan.io/address/0xf0f745c81e4533c697cf0104c5efdcbf84359542#code)
+
 
 ## Stablecoins
 
 Curve Snow pool supports swaps between the following stablecoins:
-
 
 * `yvDAI`: [0xACd43E627e64355f1861cEC6d3a6688B31a6F952](https://etherscan.io/address/0xACd43E627e64355f1861cEC6d3a6688B31a6F952)
 * `yvUSDC`: [0x597aD1e0c13Bfe8025993D9e79C69E1c0233522e](https://etherscan.io/address/0x597aD1e0c13Bfe8025993D9e79C69E1c0233522e)

--- a/contracts/pools/snow/README.md
+++ b/contracts/pools/snow/README.md
@@ -1,0 +1,33 @@
+# curve-contract/contracts/pools/y
+
+[Curve "Snow" pool](https://www.curve.fi/y), for efficient swaps of [yVault](https://feel-the-yearn.app/vaults) tokens ❄️
+
+## Contracts
+
+* [`DepositSnow`](DepositSnow.vy): Depositor contract, used to wrap underlying tokens prior to depositing them into the pool.
+* [`StableSwapSnow`](StableSwapSnow.vy): Curve stablecoin AMM contract
+
+## Deployments
+<!--
+* [`CurveContractV2`](../../tokens/CurveTokenV2.vy): []()
+* [`DepositUSDT`](DepositUSDT.vy): []()
+* [`StableSwapUSDT`](StableSwapUSDT.vy): []() -->
+
+## Stablecoins
+
+Curve Snow pool supports swaps between the following stablecoins:
+
+### Wrapped
+
+* `yvDAI`: [0xACd43E627e64355f1861cEC6d3a6688B31a6F952](https://etherscan.io/address/0xACd43E627e64355f1861cEC6d3a6688B31a6F952)
+* `yvUSDC`: [0x597aD1e0c13Bfe8025993D9e79C69E1c0233522e](https://etherscan.io/address/0x597aD1e0c13Bfe8025993D9e79C69E1c0233522e)
+* `yvUSDT`: [0x2f08119C6f07c006695E079AAFc638b8789FAf18](https://etherscan.io/address/0x2f08119C6f07c006695E079AAFc638b8789FAf18)
+* `yvTUSD`: [0x37d19d1c4E1fa9DC47bD1eA12f742a0887eDa74a](https://etherscan.io/address/0x37d19d1c4E1fa9DC47bD1eA12f742a0887eDa74a)
+* `USDC`: [0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48](https://etherscan.io/token/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48)
+
+<!-- ### Underlying
+
+* `DAI`: [0x6b175474e89094c44da98b954eedeac495271d0f](https://etherscan.io/token/0x6b175474e89094c44da98b954eedeac495271d0f)
+* `USDC`: [0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48](https://etherscan.io/token/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48)
+* `USDT`: [0xdac17f958d2ee523a2206206994597c13d831ec7](https://etherscan.io/address/0xdac17f958d2ee523a2206206994597c13d831ec7)
+* `TUSD`: [0x0000000000085d4780b73119b644ae5ecd22b376](https://etherscan.io/address/0x0000000000085d4780b73119b644ae5ecd22b376) -->

--- a/contracts/pools/snow/README.md
+++ b/contracts/pools/snow/README.md
@@ -10,24 +10,17 @@
 ## Deployments
 <!--
 * [`CurveContractV2`](../../tokens/CurveTokenV2.vy): []()
-* [`DepositUSDT`](DepositUSDT.vy): []()
-* [`StableSwapUSDT`](StableSwapUSDT.vy): []() -->
+* [`DepositSnow`](DepositSnow.vy): []()
+* [`StableSwapSnow`](StableSwapSnow.vy): []() -->
 
 ## Stablecoins
 
 Curve Snow pool supports swaps between the following stablecoins:
 
-### Wrapped
 
 * `yvDAI`: [0xACd43E627e64355f1861cEC6d3a6688B31a6F952](https://etherscan.io/address/0xACd43E627e64355f1861cEC6d3a6688B31a6F952)
 * `yvUSDC`: [0x597aD1e0c13Bfe8025993D9e79C69E1c0233522e](https://etherscan.io/address/0x597aD1e0c13Bfe8025993D9e79C69E1c0233522e)
 * `yvUSDT`: [0x2f08119C6f07c006695E079AAFc638b8789FAf18](https://etherscan.io/address/0x2f08119C6f07c006695E079AAFc638b8789FAf18)
 * `yvTUSD`: [0x37d19d1c4E1fa9DC47bD1eA12f742a0887eDa74a](https://etherscan.io/address/0x37d19d1c4E1fa9DC47bD1eA12f742a0887eDa74a)
-* `USDC`: [0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48](https://etherscan.io/token/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48)
-
-<!-- ### Underlying
-
-* `DAI`: [0x6b175474e89094c44da98b954eedeac495271d0f](https://etherscan.io/token/0x6b175474e89094c44da98b954eedeac495271d0f)
-* `USDC`: [0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48](https://etherscan.io/token/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48)
-* `USDT`: [0xdac17f958d2ee523a2206206994597c13d831ec7](https://etherscan.io/address/0xdac17f958d2ee523a2206206994597c13d831ec7)
-* `TUSD`: [0x0000000000085d4780b73119b644ae5ecd22b376](https://etherscan.io/address/0x0000000000085d4780b73119b644ae5ecd22b376) -->
+* `yvyCRV`: [0x5dbcF33D8c2E976c6b560249878e6F1491Bca25c](https://etherscan.io/address/0x5dbcF33D8c2E976c6b560249878e6F1491Bca25c)
+* `USDC`: [0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48](https://etherscan.io/address/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48)

--- a/contracts/pools/snow/StableSwapSnow.vy
+++ b/contracts/pools/snow/StableSwapSnow.vy
@@ -90,8 +90,8 @@ event StopRampA:
 
 
 # These constants must be set prior to compiling
-N_COINS: constant(int128) = ___N_COINS___
-PRECISION_MUL: constant(uint256[N_COINS]) = ___PRECISION_MUL___
+N_COINS: constant(int128) = 6
+PRECISION_MUL: constant(uint256[N_COINS]) = [1, 1000000000000, 1000000000000, 1, 1, 1000000000000]
 
 # fixed constants
 FEE_DENOMINATOR: constant(uint256) = 10 ** 10
@@ -207,8 +207,8 @@ def A() -> uint256:
 @internal
 def _stored_rates() -> uint256[N_COINS]:
     result: uint256[N_COINS] = PRECISION_MUL
-    result[4] *= 10**18
-    for i in range(4):
+    result[5] *= 10**18
+    for i in range(5):
         result[i] *= yERC20(self.coins[i]).getPricePerFullShare()
     return result
 

--- a/contracts/pools/snow/StableSwapSnow.vy
+++ b/contracts/pools/snow/StableSwapSnow.vy
@@ -1,11 +1,10 @@
-# @version ^0.2.0
+# @version 0.2.4
 """
-@title StableSwap
+@title Curve Snow pool
 @author Curve.Fi
 @license Copyright (c) Curve.Fi, 2020 - all rights reserved
-@notice Pool implementation with Yearn-style lending
-@dev This contract is only a template, pool-specific constants
-     must be set prior to compiling
+@notice Pool for swapping between yVault tokens
+@dev Swaps between yvDAI / yvUSDC / yvUSDT / yvTUSD / yvyCRV / USDC
 """
 
 from vyper.interfaces import ERC20

--- a/contracts/pools/snow/StableSwapSnow.vy
+++ b/contracts/pools/snow/StableSwapSnow.vy
@@ -1,0 +1,873 @@
+# @version ^0.2.0
+"""
+@title StableSwap
+@author Curve.Fi
+@license Copyright (c) Curve.Fi, 2020 - all rights reserved
+@notice Pool implementation with Yearn-style lending
+@dev This contract is only a template, pool-specific constants
+     must be set prior to compiling
+"""
+
+from vyper.interfaces import ERC20
+
+# External Contracts
+interface yERC20:
+    def deposit(depositAmount: uint256): nonpayable
+    def withdraw(withdrawTokens: uint256): nonpayable
+    def getPricePerFullShare() -> uint256: view
+
+
+interface CurveToken:
+    def mint(_to: address, _value: uint256) -> bool: nonpayable
+    def burnFrom(_to: address, _value: uint256) -> bool: nonpayable
+
+
+# Events
+event TokenExchange:
+    buyer: indexed(address)
+    sold_id: int128
+    tokens_sold: uint256
+    bought_id: int128
+    tokens_bought: uint256
+
+event TokenExchangeUnderlying:
+    buyer: indexed(address)
+    sold_id: int128
+    tokens_sold: uint256
+    bought_id: int128
+    tokens_bought: uint256
+
+event AddLiquidity:
+    provider: indexed(address)
+    token_amounts: uint256[N_COINS]
+    fees: uint256[N_COINS]
+    invariant: uint256
+    token_supply: uint256
+
+event RemoveLiquidity:
+    provider: indexed(address)
+    token_amounts: uint256[N_COINS]
+    fees: uint256[N_COINS]
+    token_supply: uint256
+
+event RemoveLiquidityOne:
+    provider: indexed(address)
+    token_amount: uint256
+    coin_amount: uint256
+
+event RemoveLiquidityImbalance:
+    provider: indexed(address)
+    token_amounts: uint256[N_COINS]
+    fees: uint256[N_COINS]
+    invariant: uint256
+    token_supply: uint256
+
+event CommitNewAdmin:
+    deadline: indexed(uint256)
+    admin: indexed(address)
+
+event NewAdmin:
+    admin: indexed(address)
+
+event CommitNewFee:
+    deadline: indexed(uint256)
+    fee: uint256
+    admin_fee: uint256
+
+event NewFee:
+    fee: uint256
+    admin_fee: uint256
+
+event RampA:
+    old_A: uint256
+    new_A: uint256
+    initial_time: uint256
+    future_time: uint256
+
+event StopRampA:
+    A: uint256
+    t: uint256
+
+
+# These constants must be set prior to compiling
+N_COINS: constant(int128) = ___N_COINS___
+PRECISION_MUL: constant(uint256[N_COINS]) = ___PRECISION_MUL___
+
+# fixed constants
+FEE_DENOMINATOR: constant(uint256) = 10 ** 10
+LENDING_PRECISION: constant(uint256) = 10 ** 18
+PRECISION: constant(uint256) = 10 ** 18  # The precision to convert to
+
+MAX_ADMIN_FEE: constant(uint256) = 10 * 10 ** 9
+MAX_FEE: constant(uint256) = 5 * 10 ** 9
+MAX_A: constant(uint256) = 10 ** 6
+MAX_A_CHANGE: constant(uint256) = 10
+
+ADMIN_ACTIONS_DELAY: constant(uint256) = 3 * 86400
+MIN_RAMP_TIME: constant(uint256) = 86400
+
+coins: public(address[N_COINS])
+underlying_coins: public(address[N_COINS])
+balances: public(uint256[N_COINS])
+
+fee: public(uint256)  # fee * 1e10
+admin_fee: public(uint256)  # admin_fee * 1e10
+
+owner: public(address)
+lp_token: address
+
+initial_A: public(uint256)
+future_A: public(uint256)
+initial_A_time: public(uint256)
+future_A_time: public(uint256)
+
+admin_actions_deadline: public(uint256)
+transfer_ownership_deadline: public(uint256)
+future_fee: public(uint256)
+future_admin_fee: public(uint256)
+future_owner: public(address)
+
+is_killed: bool
+kill_deadline: uint256
+KILL_DEADLINE_DT: constant(uint256) = 2 * 30 * 86400
+
+
+@external
+def __init__(
+    _owner: address,
+    _coins: address[N_COINS],
+    _underlying_coins: address[N_COINS],
+    _pool_token: address,
+    _A: uint256,
+    _fee: uint256,
+    _admin_fee: uint256,
+):
+    """
+    @notice Contract constructor
+    @param _owner Contract owner address
+    @param _coins Addresses of ERC20 contracts of wrapped coins
+    @param _underlying_coins Addresses of ERC20 contracts of underlying coins
+    @param _pool_token Address of the token representing LP share
+    @param _A Amplification coefficient multiplied by n * (n - 1)
+    @param _fee Fee to charge for exchanges
+    @param _admin_fee Admin fee
+    """
+    for i in range(N_COINS):
+        assert _coins[i] != ZERO_ADDRESS
+        assert _underlying_coins[i] != ZERO_ADDRESS
+
+        # approve underlying coins for infinite transfers
+        _response: Bytes[32] = raw_call(
+            _underlying_coins[i],
+            concat(
+                method_id("approve(address,uint256)"),
+                convert(_coins[i], bytes32),
+                convert(MAX_UINT256, bytes32),
+            ),
+            max_outsize=32,
+        )
+        if len(_response) > 0:
+            assert convert(_response, bool)
+
+    self.coins = _coins
+    self.underlying_coins = _underlying_coins
+    self.initial_A = _A
+    self.future_A = _A
+    self.fee = _fee
+    self.admin_fee = _admin_fee
+    self.owner = _owner
+    self.kill_deadline = block.timestamp + KILL_DEADLINE_DT
+    self.lp_token = _pool_token
+
+
+@view
+@internal
+def _A() -> uint256:
+    """
+    Handle ramping A up or down
+    """
+    t1: uint256 = self.future_A_time
+    A1: uint256 = self.future_A
+
+    if block.timestamp < t1:
+        A0: uint256 = self.initial_A
+        t0: uint256 = self.initial_A_time
+        # Expressions in uint256 cannot have negative numbers, thus "if"
+        if A1 > A0:
+            return A0 + (A1 - A0) * (block.timestamp - t0) / (t1 - t0)
+        else:
+            return A0 - (A0 - A1) * (block.timestamp - t0) / (t1 - t0)
+
+    else:  # when t1 == 0 or block.timestamp >= t1
+        return A1
+
+
+@view
+@external
+def A() -> uint256:
+    return self._A()
+
+
+@view
+@internal
+def _stored_rates() -> uint256[N_COINS]:
+    result: uint256[N_COINS] = PRECISION_MUL
+    for i in range(N_COINS):
+        result[i] *= yERC20(self.coins[i]).getPricePerFullShare()
+    return result
+
+
+@view
+@internal
+def _xp(rates: uint256[N_COINS]) -> uint256[N_COINS]:
+    result: uint256[N_COINS] = rates
+    for i in range(N_COINS):
+        result[i] = result[i] * self.balances[i] / PRECISION
+    return result
+
+
+@pure
+@internal
+def _xp_mem(rates: uint256[N_COINS], _balances: uint256[N_COINS]) -> uint256[N_COINS]:
+    result: uint256[N_COINS] = rates
+    for i in range(N_COINS):
+        result[i] = result[i] * _balances[i] / PRECISION
+    return result
+
+
+@internal
+@view
+def get_D(xp: uint256[N_COINS], amp: uint256) -> uint256:
+    S: uint256 = 0
+    for _x in xp:
+        S += _x
+    if S == 0:
+        return 0
+
+    Dprev: uint256 = 0
+    D: uint256 = S
+    Ann: uint256 = amp * N_COINS
+    for _i in range(255):
+        D_P: uint256 = D
+        for _x in xp:
+            D_P = D_P * D / (_x * N_COINS)  # If division by 0, this will be borked: only withdrawal will work. And that is good
+        Dprev = D
+        D = (Ann * S + D_P * N_COINS) * D / ((Ann - 1) * D + (N_COINS + 1) * D_P)
+        # Equality with the precision of 1
+        if D > Dprev:
+            if D - Dprev <= 1:
+                break
+        else:
+            if Dprev - D <= 1:
+                break
+    return D
+
+
+@view
+@internal
+def get_D_mem(rates: uint256[N_COINS], _balances: uint256[N_COINS]) -> uint256:
+    return self.get_D(self._xp_mem(rates, _balances), self._A())
+
+
+@view
+@external
+def get_virtual_price() -> uint256:
+    """
+    Returns portfolio virtual price (for calculating profit)
+    scaled up by 1e18
+    """
+    D: uint256 = self.get_D(self._xp(self._stored_rates()), self._A())
+    # D is in the units similar to DAI (e.g. converted to precision 1e18)
+    # When balanced, D = n * x_u - total virtual value of the portfolio
+    token_supply: uint256 = ERC20(self.lp_token).totalSupply()
+    return D * PRECISION / token_supply
+
+
+@view
+@external
+def calc_token_amount(amounts: uint256[N_COINS], deposit: bool) -> uint256:
+    """
+    Simplified method to calculate addition or reduction in token supply at
+    deposit or withdrawal without taking fees into account (but looking at
+    slippage).
+    Needed to prevent front-running, not for precise calculations!
+    """
+    _balances: uint256[N_COINS] = self.balances
+    rates: uint256[N_COINS] = self._stored_rates()
+    D0: uint256 = self.get_D_mem(rates, _balances)
+    for i in range(N_COINS):
+        if deposit:
+            _balances[i] += amounts[i]
+        else:
+            _balances[i] -= amounts[i]
+    D1: uint256 = self.get_D_mem(rates, _balances)
+    token_amount: uint256 = ERC20(self.lp_token).totalSupply()
+    diff: uint256 = 0
+    if deposit:
+        diff = D1 - D0
+    else:
+        diff = D0 - D1
+    return diff * token_amount / D0
+
+
+@external
+@nonreentrant('lock')
+def add_liquidity(amounts: uint256[N_COINS], min_mint_amount: uint256):
+    assert not self.is_killed
+
+    fees: uint256[N_COINS] = empty(uint256[N_COINS])
+    _fee: uint256 = self.fee * N_COINS / (4 * (N_COINS - 1))
+    _admin_fee: uint256 = self.admin_fee
+    _lp_token: address = self.lp_token
+
+    token_supply: uint256 = ERC20(_lp_token).totalSupply()
+    rates: uint256[N_COINS] = self._stored_rates()
+    # Initial invariant
+    D0: uint256 = 0
+    old_balances: uint256[N_COINS] = self.balances
+    if token_supply != 0:
+        D0 = self.get_D_mem(rates, old_balances)
+    new_balances: uint256[N_COINS] = old_balances
+
+    for i in range(N_COINS):
+        if token_supply == 0:
+            assert amounts[i] > 0
+        # balances store amounts of c-tokens
+        new_balances[i] = old_balances[i] + amounts[i]
+
+    # Invariant after change
+    D1: uint256 = self.get_D_mem(rates, new_balances)
+    assert D1 > D0
+
+    # We need to recalculate the invariant accounting for fees
+    # to calculate fair user's share
+    D2: uint256 = D1
+    if token_supply != 0:
+        # Only account for fees if we are not the first to deposit
+        for i in range(N_COINS):
+            ideal_balance: uint256 = D1 * old_balances[i] / D0
+            difference: uint256 = 0
+            if ideal_balance > new_balances[i]:
+                difference = ideal_balance - new_balances[i]
+            else:
+                difference = new_balances[i] - ideal_balance
+            fees[i] = _fee * difference / FEE_DENOMINATOR
+            self.balances[i] = new_balances[i] - (fees[i] * _admin_fee / FEE_DENOMINATOR)
+            new_balances[i] -= fees[i]
+        D2 = self.get_D_mem(rates, new_balances)
+    else:
+        self.balances = new_balances
+
+    # Calculate, how much pool tokens to mint
+    mint_amount: uint256 = 0
+    if token_supply == 0:
+        mint_amount = D1  # Take the dust if there was any
+    else:
+        mint_amount = token_supply * (D2 - D0) / D0
+
+    assert mint_amount >= min_mint_amount, "Slippage screwed you"
+
+    # Take coins from the sender
+    for i in range(N_COINS):
+        if amounts[i] != 0:
+            assert ERC20(self.coins[i]).transferFrom(msg.sender, self, amounts[i])
+
+    # Mint pool tokens
+    CurveToken(_lp_token).mint(msg.sender, mint_amount)
+
+    log AddLiquidity(msg.sender, amounts, fees, D1, token_supply + mint_amount)
+
+
+@view
+@internal
+def get_y(i: int128, j: int128, x: uint256, xp_: uint256[N_COINS]) -> uint256:
+    # x in the input is converted to the same price/precision
+
+    assert i != j       # dev: same coin
+    assert j >= 0       # dev: j below zero
+    assert j < N_COINS  # dev: j above N_COINS
+
+    # should be unreachable, but good for safety
+    assert i >= 0
+    assert i < N_COINS
+
+    A_: uint256 = self._A()
+    D: uint256 = self.get_D(xp_, A_)
+    c: uint256 = D
+    S_: uint256 = 0
+    Ann: uint256 = A_ * N_COINS
+
+    _x: uint256 = 0
+    for _i in range(N_COINS):
+        if _i == i:
+            _x = x
+        elif _i != j:
+            _x = xp_[_i]
+        else:
+            continue
+        S_ += _x
+        c = c * D / (_x * N_COINS)
+    c = c * D / (Ann * N_COINS)
+    b: uint256 = S_ + D / Ann  # - D
+    y_prev: uint256 = 0
+    y: uint256 = D
+    for _i in range(255):
+        y_prev = y
+        y = (y*y + c) / (2 * y + b - D)
+        # Equality with the precision of 1
+        if y > y_prev:
+            if y - y_prev <= 1:
+                break
+        else:
+            if y_prev - y <= 1:
+                break
+    return y
+
+
+@view
+@external
+def get_dy(i: int128, j: int128, dx: uint256) -> uint256:
+    rates: uint256[N_COINS] = self._stored_rates()
+    xp: uint256[N_COINS] = self._xp(rates)
+
+    x: uint256 = xp[i] + dx * rates[i] / PRECISION
+    y: uint256 = self.get_y(i, j, x, xp)
+    dy: uint256 = xp[j] - y
+    _fee: uint256 = self.fee * dy / FEE_DENOMINATOR
+    return (dy - _fee) * PRECISION / rates[j]
+
+
+@view
+@external
+def get_dx(i: int128, j: int128, dy: uint256) -> uint256:
+    # dx and dy in c-units
+    rates: uint256[N_COINS] = self._stored_rates()
+    xp: uint256[N_COINS] = self._xp(rates)
+
+    y: uint256 = xp[j] - (dy * FEE_DENOMINATOR / (FEE_DENOMINATOR - self.fee)) * rates[j] / PRECISION
+    x: uint256 = self.get_y(j, i, y, xp)
+    dx: uint256 = (x - xp[i]) * PRECISION / rates[i]
+    return dx
+
+
+@view
+@external
+def get_dy_underlying(i: int128, j: int128, dx: uint256) -> uint256:
+    # dx and dy in underlying units
+    rates: uint256[N_COINS] = self._stored_rates()
+    xp: uint256[N_COINS] = self._xp(rates)
+    precisions: uint256[N_COINS] = PRECISION_MUL
+
+    x: uint256 = xp[i] + dx * precisions[i]
+    y: uint256 = self.get_y(i, j, x, xp)
+    dy: uint256 = (xp[j] - y - 1) / precisions[j]
+    _fee: uint256 = self.fee * dy / FEE_DENOMINATOR
+    return dy - _fee
+
+
+@external
+@view
+def get_dx_underlying(i: int128, j: int128, dy: uint256) -> uint256:
+    # dx and dy in underlying units
+    rates: uint256[N_COINS] = self._stored_rates()
+    xp: uint256[N_COINS] = self._xp(rates)
+    precisions: uint256[N_COINS] = PRECISION_MUL
+
+    y: uint256 = xp[j] - (dy * FEE_DENOMINATOR / (FEE_DENOMINATOR - self.fee)) * precisions[j]
+    x: uint256 = self.get_y(j, i, y, xp)
+    dx: uint256 = (x - xp[i]) / precisions[i]
+    return dx
+
+
+@internal
+def _exchange(i: int128, j: int128, dx: uint256, rates: uint256[N_COINS]) -> uint256:
+    assert not self.is_killed
+    # dx and dy are in c-tokens
+
+    xp: uint256[N_COINS] = self._xp(rates)
+
+    x: uint256 = xp[i] + dx * rates[i] / PRECISION
+    y: uint256 = self.get_y(i, j, x, xp)
+    dy: uint256 = xp[j] - y - 1  # -1 just in case there were some rounding errors
+    dy_fee: uint256 = dy * self.fee / FEE_DENOMINATOR
+    dy_admin_fee: uint256 = dy_fee * self.admin_fee / FEE_DENOMINATOR
+
+    self.balances[i] = x * PRECISION / rates[i]
+    self.balances[j] = (y + (dy_fee - dy_admin_fee)) * PRECISION / rates[j]
+
+    _dy: uint256 = (dy - dy_fee) * PRECISION / rates[j]
+
+    return _dy
+
+
+@external
+@nonreentrant('lock')
+def exchange(i: int128, j: int128, dx: uint256, min_dy: uint256):
+    rates: uint256[N_COINS] = self._stored_rates()
+    dy: uint256 = self._exchange(i, j, dx, rates)
+    assert dy >= min_dy, "Exchange resulted in fewer coins than expected"
+
+    assert ERC20(self.coins[i]).transferFrom(msg.sender, self, dx)
+    assert ERC20(self.coins[j]).transfer(msg.sender, dy)
+
+    log TokenExchange(msg.sender, i, dx, j, dy)
+
+
+@external
+@nonreentrant('lock')
+def exchange_underlying(i: int128, j: int128, dx: uint256, min_dy: uint256):
+    rates: uint256[N_COINS] = self._stored_rates()
+    precisions: uint256[N_COINS] = PRECISION_MUL
+    rate_i: uint256 = rates[i] / precisions[i]
+    rate_j: uint256 = rates[j] / precisions[j]
+    dx_: uint256 = dx * PRECISION / rate_i
+
+    dy_: uint256 = self._exchange(i, j, dx_, rates)
+    dy: uint256 = dy_ * rate_j / PRECISION
+    assert dy >= min_dy, "Exchange resulted in fewer coins than expected"
+
+    _response: Bytes[32] = raw_call(
+        self.underlying_coins[i],
+        concat(
+            method_id("transferFrom(address,address,uint256)"),
+            convert(msg.sender, bytes32),
+            convert(self, bytes32),
+            convert(dx, bytes32),
+        ),
+        max_outsize=32,
+    )
+    if len(_response) > 0:
+        assert convert(_response, bool)
+
+    yERC20(self.coins[i]).deposit(dx)
+    yERC20(self.coins[j]).withdraw(dy_)
+
+    # y-tokens calculate imprecisely - use all available
+    dy = ERC20(self.underlying_coins[j]).balanceOf(self)
+    assert dy >= min_dy, "Exchange resulted in fewer coins than expected"
+
+    _response = raw_call(
+        self.underlying_coins[j],
+        concat(
+            method_id("transfer(address,uint256)"),
+            convert(msg.sender, bytes32),
+            convert(dy, bytes32),
+        ),
+        max_outsize=32,
+    )
+    if len(_response) > 0:
+        assert convert(_response, bool)
+
+    log TokenExchangeUnderlying(msg.sender, i, dx, j, dy)
+
+
+@external
+@nonreentrant('lock')
+def remove_liquidity(_amount: uint256, min_amounts: uint256[N_COINS]):
+    total_supply: uint256 = ERC20(self.lp_token).totalSupply()
+    amounts: uint256[N_COINS] = empty(uint256[N_COINS])
+    fees: uint256[N_COINS] = empty(uint256[N_COINS])
+
+    for i in range(N_COINS):
+        _balance: uint256 = self.balances[i]
+        value: uint256 = _balance * _amount / total_supply
+        assert value >= min_amounts[i], "Withdrawal resulted in fewer coins than expected"
+        self.balances[i] = _balance - value
+        amounts[i] = value
+        assert ERC20(self.coins[i]).transfer(msg.sender, value)
+
+    CurveToken(self.lp_token).burnFrom(msg.sender, _amount)  # Will raise if not enough
+
+    log RemoveLiquidity(msg.sender, amounts, fees, total_supply - _amount)
+
+
+@external
+@nonreentrant('lock')
+def remove_liquidity_imbalance(amounts: uint256[N_COINS], max_burn_amount: uint256):
+    assert not self.is_killed
+
+    _lp_token: address = self.lp_token
+    token_supply: uint256 = ERC20(_lp_token).totalSupply()
+    assert token_supply != 0
+    _fee: uint256 = self.fee * N_COINS / (4 * (N_COINS - 1))
+    _admin_fee: uint256 = self.admin_fee
+    rates: uint256[N_COINS] = self._stored_rates()
+
+    old_balances: uint256[N_COINS] = self.balances
+    new_balances: uint256[N_COINS] = old_balances
+    D0: uint256 = self.get_D_mem(rates, old_balances)
+    for i in range(N_COINS):
+        new_balances[i] -= amounts[i]
+    D1: uint256 = self.get_D_mem(rates, new_balances)
+    fees: uint256[N_COINS] = empty(uint256[N_COINS])
+    for i in range(N_COINS):
+        ideal_balance: uint256 = D1 * old_balances[i] / D0
+        difference: uint256 = 0
+        if ideal_balance > new_balances[i]:
+            difference = ideal_balance - new_balances[i]
+        else:
+            difference = new_balances[i] - ideal_balance
+        fees[i] = _fee * difference / FEE_DENOMINATOR
+        self.balances[i] = new_balances[i] - (fees[i] * _admin_fee / FEE_DENOMINATOR)
+        new_balances[i] -= fees[i]
+    D2: uint256 = self.get_D_mem(rates, new_balances)
+
+    token_amount: uint256 = (D0 - D2) * token_supply / D0
+    assert token_amount != 0
+    assert token_amount <= max_burn_amount, "Slippage screwed you"
+
+    CurveToken(_lp_token).burnFrom(msg.sender, token_amount)  # dev: insufficient funds
+    for i in range(N_COINS):
+        if amounts[i] != 0:
+            assert ERC20(self.coins[i]).transfer(msg.sender, amounts[i])
+
+    log RemoveLiquidityImbalance(msg.sender, amounts, fees, D1, token_supply - token_amount)
+
+
+@pure
+@internal
+def get_y_D(A_: uint256, i: int128, xp: uint256[N_COINS], D: uint256) -> uint256:
+    """
+    Calculate x[i] if one reduces D from being calculated for xp to D
+
+    Done by solving quadratic equation iteratively.
+    x_1**2 + x1 * (sum' - (A*n**n - 1) * D / (A * n**n)) = D ** (n + 1) / (n ** (2 * n) * prod' * A)
+    x_1**2 + b*x_1 = c
+
+    x_1 = (x_1**2 + c) / (2*x_1 + b)
+    """
+    # x in the input is converted to the same price/precision
+
+    assert i >= 0  # dev: i below zero
+    assert i < N_COINS  # dev: i above N_COINS
+
+    c: uint256 = D
+    S_: uint256 = 0
+    Ann: uint256 = A_ * N_COINS
+
+    _x: uint256 = 0
+    for _i in range(N_COINS):
+        if _i != i:
+            _x = xp[_i]
+        else:
+            continue
+        S_ += _x
+        c = c * D / (_x * N_COINS)
+    c = c * D / (Ann * N_COINS)
+    b: uint256 = S_ + D / Ann
+    y_prev: uint256 = 0
+    y: uint256 = D
+    for _i in range(255):
+        y_prev = y
+        y = (y*y + c) / (2 * y + b - D)
+        # Equality with the precision of 1
+        if y > y_prev:
+            if y - y_prev <= 1:
+                break
+        else:
+            if y_prev - y <= 1:
+                break
+    return y
+
+
+@view
+@internal
+def _calc_withdraw_one_coin(_token_amount: uint256, i: int128) -> (uint256, uint256):
+    # First, need to calculate
+    # * Get current D
+    # * Solve Eqn against y_i for D - _token_amount
+    amp: uint256 = self._A()
+    _fee: uint256 = self.fee * N_COINS / (4 * (N_COINS - 1))
+    precisions: uint256[N_COINS] = PRECISION_MUL
+    total_supply: uint256 = ERC20(self.lp_token).totalSupply()
+
+    xp: uint256[N_COINS] = self._xp(self._stored_rates())
+
+    D0: uint256 = self.get_D(xp, amp)
+    D1: uint256 = D0 - _token_amount * D0 / total_supply
+    xp_reduced: uint256[N_COINS] = xp
+
+    new_y: uint256 = self.get_y_D(amp, i, xp, D1)
+    dy_0: uint256 = (xp[i] - new_y) / precisions[i]  # w/o fees
+
+    for j in range(N_COINS):
+        dx_expected: uint256 = 0
+        if j == i:
+            dx_expected = xp[j] * D1 / D0 - new_y
+        else:
+            dx_expected = xp[j] - xp[j] * D1 / D0
+        xp_reduced[j] -= _fee * dx_expected / FEE_DENOMINATOR
+
+    dy: uint256 = xp_reduced[i] - self.get_y_D(amp, i, xp_reduced, D1)
+    dy = (dy - 1) / precisions[i]  # Withdraw less to account for rounding errors
+
+    return dy, dy_0 - dy
+
+
+@view
+@external
+def calc_withdraw_one_coin(_token_amount: uint256, i: int128) -> uint256:
+    return self._calc_withdraw_one_coin(_token_amount, i)[0]
+
+
+@external
+@nonreentrant('lock')
+def remove_liquidity_one_coin(_token_amount: uint256, i: int128, min_amount: uint256):
+    """
+    Remove _amount of liquidity all in a form of coin i
+    """
+    assert not self.is_killed  # dev: is killed
+
+    dy: uint256 = 0
+    dy_fee: uint256 = 0
+    dy, dy_fee = self._calc_withdraw_one_coin(_token_amount, i)
+    assert dy >= min_amount, "Not enough coins removed"
+
+    self.balances[i] -= (dy + dy_fee * self.admin_fee / FEE_DENOMINATOR)
+    CurveToken(self.lp_token).burnFrom(msg.sender, _token_amount)  # dev: insufficient funds
+    assert ERC20(self.coins[i]).transfer(msg.sender, dy)
+
+    log RemoveLiquidityOne(msg.sender, _token_amount, dy)
+
+
+### Admin functions ###
+@external
+def ramp_A(_future_A: uint256, _future_time: uint256):
+    assert msg.sender == self.owner  # dev: only owner
+    assert block.timestamp >= self.initial_A_time + MIN_RAMP_TIME
+    assert _future_time >= block.timestamp + MIN_RAMP_TIME  # dev: insufficient time
+
+    _initial_A: uint256 = self._A()
+
+    assert _future_A > 0 and _future_A < MAX_A
+    if _future_A < _initial_A:
+        assert _future_A * MAX_A_CHANGE >= _initial_A
+    else:
+        assert _future_A <= _initial_A * MAX_A_CHANGE
+
+    self.initial_A = _initial_A
+    self.future_A = _future_A
+    self.initial_A_time = block.timestamp
+    self.future_A_time = _future_time
+
+    log RampA(_initial_A, _future_A, block.timestamp, _future_time)
+
+
+@external
+def stop_ramp_A():
+    assert msg.sender == self.owner  # dev: only owner
+
+    current_A: uint256 = self._A()
+    self.initial_A = current_A
+    self.future_A = current_A
+    self.initial_A_time = block.timestamp
+    self.future_A_time = block.timestamp
+    # now (block.timestamp < t1) is always False, so we return saved A
+
+    log StopRampA(current_A, block.timestamp)
+
+
+@external
+def commit_new_fee(new_fee: uint256, new_admin_fee: uint256):
+    assert msg.sender == self.owner  # dev: only owner
+    assert self.admin_actions_deadline == 0  # dev: active action
+    assert new_fee <= MAX_FEE  # dev: fee exceeds maximum
+    assert new_admin_fee <= MAX_ADMIN_FEE  # dev: admin fee exceeds maximum
+
+    _deadline: uint256 = block.timestamp + ADMIN_ACTIONS_DELAY
+    self.admin_actions_deadline = _deadline
+    self.future_fee = new_fee
+    self.future_admin_fee = new_admin_fee
+
+    log CommitNewFee(_deadline, new_fee, new_admin_fee)
+
+
+@external
+def apply_new_fee():
+    assert msg.sender == self.owner  # dev: only owner
+    assert block.timestamp >= self.admin_actions_deadline  # dev: insufficient time
+    assert self.admin_actions_deadline != 0  # dev: no active action
+
+    self.admin_actions_deadline = 0
+    _fee: uint256 = self.future_fee
+    _admin_fee: uint256 = self.future_admin_fee
+    self.fee = _fee
+    self.admin_fee = _admin_fee
+
+    log NewFee(_fee, _admin_fee)
+
+
+@external
+def revert_new_parameters():
+    assert msg.sender == self.owner  # dev: only owner
+
+    self.admin_actions_deadline = 0
+
+
+@external
+def commit_transfer_ownership(_owner: address):
+    assert msg.sender == self.owner  # dev: only owner
+    assert self.transfer_ownership_deadline == 0  # dev: active transfer
+
+    _deadline: uint256 = block.timestamp + ADMIN_ACTIONS_DELAY
+    self.transfer_ownership_deadline = _deadline
+    self.future_owner = _owner
+
+    log CommitNewAdmin(_deadline, _owner)
+
+
+@external
+def apply_transfer_ownership():
+    assert msg.sender == self.owner  # dev: only owner
+    assert block.timestamp >= self.transfer_ownership_deadline  # dev: insufficient time
+    assert self.transfer_ownership_deadline != 0  # dev: no active transfer
+
+    self.transfer_ownership_deadline = 0
+    _owner: address = self.future_owner
+    self.owner = _owner
+
+    log NewAdmin(_owner)
+
+
+@external
+def revert_transfer_ownership():
+    assert msg.sender == self.owner  # dev: only owner
+
+    self.transfer_ownership_deadline = 0
+
+
+@view
+@external
+def admin_balances(i: uint256) -> uint256:
+    return ERC20(self.coins[i]).balanceOf(self) - self.balances[i]
+
+
+@external
+def withdraw_admin_fees():
+    assert msg.sender == self.owner  # dev: only owner
+
+    for i in range(N_COINS):
+        c: address = self.coins[i]
+        value: uint256 = ERC20(c).balanceOf(self) - self.balances[i]
+        if value > 0:
+            assert ERC20(c).transfer(msg.sender, value)
+
+
+@external
+def donate_admin_fees():
+    assert msg.sender == self.owner  # dev: only owner
+    for i in range(N_COINS):
+        self.balances[i] = ERC20(self.coins[i]).balanceOf(self)
+
+
+@external
+def kill_me():
+    assert msg.sender == self.owner  # dev: only owner
+    assert self.kill_deadline > block.timestamp  # dev: deadline has passed
+    self.is_killed = True
+
+
+@external
+def unkill_me():
+    assert msg.sender == self.owner  # dev: only owner
+    self.is_killed = False

--- a/contracts/pools/snow/StableSwapSnow.vy
+++ b/contracts/pools/snow/StableSwapSnow.vy
@@ -119,6 +119,7 @@ initial_A: public(uint256)
 future_A: public(uint256)
 initial_A_time: public(uint256)
 future_A_time: public(uint256)
+A_PRECISION: constant(uint256) = 100
 
 admin_actions_deadline: public(uint256)
 transfer_ownership_deadline: public(uint256)
@@ -170,8 +171,8 @@ def __init__(
             assert convert(_response, bool)
 
     self.coins = _coins
-    self.initial_A = _A
-    self.future_A = _A
+    self.initial_A = _A * A_PRECISION
+    self.future_A = _A * A_PRECISION
     self.fee = _fee
     self.admin_fee = _admin_fee
     self.owner = _owner
@@ -206,6 +207,12 @@ def _A() -> uint256:
 @view
 @external
 def A() -> uint256:
+    return self._A() / A_PRECISION
+
+
+@view
+@external
+def A_precise() -> uint256:
     return self._A()
 
 
@@ -266,7 +273,7 @@ def get_D(xp: uint256[N_COINS], amp: uint256) -> uint256:
         for _x in xp:
             D_P = D_P * D / (_x * N_COINS)  # If division by 0, this will be borked: only withdrawal will work. And that is good
         Dprev = D
-        D = (Ann * S + D_P * N_COINS) * D / ((Ann - 1) * D + (N_COINS + 1) * D_P)
+        D = (Ann * S / A_PRECISION + D_P * N_COINS) * D / ((Ann - A_PRECISION) * D / A_PRECISION + (N_COINS + 1) * D_P)
         # Equality with the precision of 1
         if D > Dprev:
             if D - Dprev <= 1:
@@ -422,8 +429,8 @@ def get_y(i: int128, j: int128, x: uint256, xp_: uint256[N_COINS]) -> uint256:
             continue
         S_ += _x
         c = c * D / (_x * N_COINS)
-    c = c * D / (Ann * N_COINS)
-    b: uint256 = S_ + D / Ann  # - D
+    c = c * D * A_PRECISION / (Ann * N_COINS)
+    b: uint256 = S_ + D * A_PRECISION / Ann  # - D
     y_prev: uint256 = 0
     y: uint256 = D
     for _i in range(255):
@@ -588,8 +595,8 @@ def get_y_D(A_: uint256, i: int128, xp: uint256[N_COINS], D: uint256) -> uint256
             continue
         S_ += _x
         c = c * D / (_x * N_COINS)
-    c = c * D / (Ann * N_COINS)
-    b: uint256 = S_ + D / Ann
+    c = c * D * A_PRECISION / (Ann * N_COINS)
+    b: uint256 = S_ + D * A_PRECISION / Ann
     y_prev: uint256 = 0
     y: uint256 = D
     for _i in range(255):
@@ -674,19 +681,20 @@ def ramp_A(_future_A: uint256, _future_time: uint256):
     assert _future_time >= block.timestamp + MIN_RAMP_TIME  # dev: insufficient time
 
     _initial_A: uint256 = self._A()
+    _future_A_p: uint256 = _future_A * A_PRECISION
 
     assert _future_A > 0 and _future_A < MAX_A
-    if _future_A < _initial_A:
-        assert _future_A * MAX_A_CHANGE >= _initial_A
+    if _future_A_p < _initial_A:
+        assert _future_A_p * MAX_A_CHANGE >= _initial_A
     else:
-        assert _future_A <= _initial_A * MAX_A_CHANGE
+        assert _future_A_p <= _initial_A * MAX_A_CHANGE
 
     self.initial_A = _initial_A
-    self.future_A = _future_A
+    self.future_A = _future_A_p
     self.initial_A_time = block.timestamp
     self.future_A_time = _future_time
 
-    log RampA(_initial_A, _future_A, block.timestamp, _future_time)
+    log RampA(_initial_A, _future_A_p, block.timestamp, _future_time)
 
 
 @external

--- a/contracts/pools/snow/pooldata.json
+++ b/contracts/pools/snow/pooldata.json
@@ -1,0 +1,12 @@
+{
+
+    "lp_contract": "CurveTokenV2",
+    "wrapped_contract": "yERC20",
+    "coins": [
+        {"decimals": 18, "tethered": false, "wrapped": true, "wrapped_decimals": 18},
+        {"decimals": 6, "tethered": false, "wrapped": true, "wrapped_decimals": 6},
+        {"decimals": 6, "tethered": true, "wrapped": true, "wrapped_decimals": 6},
+        {"decimals": 18, "tethered": false, "wrapped": true, "wrapped_decimals": 18},
+        {"decimals": 6, "tethered": false, "wrapped": false}
+    ]
+}

--- a/contracts/pools/snow/pooldata.json
+++ b/contracts/pools/snow/pooldata.json
@@ -3,10 +3,10 @@
     "lp_contract": "CurveTokenV2",
     "wrapped_contract": "yERC20",
     "coins": [
-        {"decimals": 18, "tethered": false, "wrapped": true, "wrapped_decimals": 18},
-        {"decimals": 6, "tethered": false, "wrapped": true, "wrapped_decimals": 6},
-        {"decimals": 6, "tethered": true, "wrapped": true, "wrapped_decimals": 6},
-        {"decimals": 18, "tethered": false, "wrapped": true, "wrapped_decimals": 18},
+        {"decimals": 18, "tethered": false, "wrapped": true, "wrapped_decimals": 18, "withdrawal_fee": 500},
+        {"decimals": 6, "tethered": false, "wrapped": true, "wrapped_decimals": 6, "withdrawal_fee": 500},
+        {"decimals": 6, "tethered": true, "wrapped": true, "wrapped_decimals": 6, "withdrawal_fee": 500},
+        {"decimals": 18, "tethered": false, "wrapped": true, "wrapped_decimals": 18, "withdrawal_fee": 500},
         {"decimals": 6, "tethered": false, "wrapped": false}
     ]
 }

--- a/contracts/pools/snow/pooldata.json
+++ b/contracts/pools/snow/pooldata.json
@@ -7,6 +7,7 @@
         {"decimals": 6, "tethered": false, "wrapped": true, "wrapped_decimals": 6, "withdrawal_fee": 500},
         {"decimals": 6, "tethered": true, "wrapped": true, "wrapped_decimals": 6, "withdrawal_fee": 500},
         {"decimals": 18, "tethered": false, "wrapped": true, "wrapped_decimals": 18, "withdrawal_fee": 500},
+        {"decimals": 18, "tethered": false, "wrapped": true, "wrapped_decimals": 18, "withdrawal_fee": 500},
         {"decimals": 6, "tethered": false, "wrapped": false}
     ]
 }

--- a/contracts/testing/SwapMock.vy
+++ b/contracts/testing/SwapMock.vy
@@ -1,0 +1,19 @@
+# @version ^0.2.0
+# Minimal StableSwap mock for testing snow pool
+
+virtual_price: uint256
+
+@external
+def __init__():
+    self.virtual_price = 10 ** 18
+
+
+@view
+@external
+def get_virtual_price() -> uint256:
+    return self.virtual_price
+
+
+@external
+def _set_virtual_price(_value: uint256):
+    self.virtual_price = _value

--- a/contracts/testing/yERC20.vy
+++ b/contracts/testing/yERC20.vy
@@ -23,6 +23,7 @@ total_supply: uint256
 
 token: ERC20
 getPricePerFullShare: public(uint256)  # yERC20 mock
+withdrawal_fee: uint256
 
 @public
 def __init__(_name: string[64], _symbol: string[32], _decimals: uint256, _supply: uint256,
@@ -132,6 +133,11 @@ def withdraw(withdrawTokens: uint256):
      @param withdrawTokens The number of yTokens to redeem into underlying
     """
     uvalue: uint256 = withdrawTokens * self.getPricePerFullShare / 10 ** 18
+
+    fee: uint256 = self.withdrawal_fee
+    if fee > 0:
+        uvalue -= uvalue * fee / 10000
+
     self.balanceOf[msg.sender] -= withdrawTokens
     self.total_supply -= withdrawTokens
     self.token.transfer(msg.sender, uvalue)
@@ -140,6 +146,12 @@ def withdraw(withdrawTokens: uint256):
 @public
 def set_exchange_rate(rate: uint256):
     self.getPricePerFullShare = rate
+
+
+@public
+def _set_withdrawal_fee(pct: uint256):
+    # set a withdrawal fee, expressed as a percentage in bps
+    self.withdrawal_fee = pct
 
 
 @public

--- a/tests/fixtures/deployments.py
+++ b/tests/fixtures/deployments.py
@@ -53,7 +53,7 @@ def pool_token(project, alice, pool_data):
 
 
 @pytest.fixture(scope="module")
-def swap(project, alice, underlying_coins, wrapped_coins, pool_token, pool_data):
+def swap(project, alice, underlying_coins, wrapped_coins, pool_token, pool_data, swap_mock):
     deployer = getattr(project, pool_data['swap_contract'])
 
     abi = next(i['inputs'] for i in deployer.abi if i['type'] == "constructor")
@@ -66,6 +66,7 @@ def swap(project, alice, underlying_coins, wrapped_coins, pool_token, pool_data)
         '_admin_fee': 0,
         '_offpeg_fee_multiplier': 0,
         '_owner': alice,
+        '_y_pool': swap_mock,
     }
     deployment_args = [args[i['name']] for i in abi] + [({'from': alice})]
 
@@ -137,3 +138,11 @@ def registry(
 @pytest.fixture(scope="module")
 def gauge_controller(GaugeControllerMock, alice):
     yield GaugeControllerMock.deploy({'from': alice})
+
+
+@pytest.fixture(scope="module")
+def swap_mock(SwapMock, pool_data, alice):
+    if pool_data['name'] == "snow":
+        yield SwapMock.deploy({'from': alice})
+    else:
+        yield False

--- a/tests/fixtures/deployments.py
+++ b/tests/fixtures/deployments.py
@@ -24,6 +24,10 @@ def wrapped_coins(project, alice, pool_data, underlying_coins):
                 )
                 for target, attr in fn_names.items():
                     setattr(contract, target, getattr(contract, attr))
+
+                if coin_data.get("withdrawal_fee"):
+                    contract._set_withdrawal_fee(coin_data["withdrawal_fee"], {'from': alice})
+
                 coins.append(contract)
 
         yield coins

--- a/tests/pools/common/integration/test_virtual_price_increases.py
+++ b/tests/pools/common/integration/test_virtual_price_increases.py
@@ -1,0 +1,61 @@
+import pytest
+from brownie.test import given, strategy
+from hypothesis import settings
+
+pytestmark = pytest.mark.usefixtures("add_initial_liquidity", "mint_bob", "approve_bob")
+
+
+@given(
+    st_coin=strategy('decimal[100]', min_value=0, max_value="0.99", unique=True, places=2),
+    st_divisor=strategy('uint[50]', min_value=1, max_value=100, unique=True),
+)
+@settings(max_examples=5)
+def test_number_go_up(
+    chain,
+    bob,
+    wrapped_coins,
+    wrapped_decimals,
+    swap,
+    n_coins,
+    st_coin,
+    st_divisor,
+    set_fees,
+):
+    """
+    Perform a series of token swaps and compare the resulting amounts and pool balances
+    with those in our python-based model.
+
+    Strategies
+    ----------
+    st_coin : decimal[100]
+        Array of decimal values, used to choose the coins used in each swap
+    st_divisor: uint[50]
+        Array of integers, used to choose the size of each swap
+    """
+
+    set_fees(10**7, 0)
+
+    rate_mul = [10**i for i in wrapped_decimals]
+    while st_coin:
+        # Tune exchange rates
+        for coin in wrapped_coins:
+            if hasattr(coin, 'set_exchange_rate'):
+                rate = int(coin.get_rate() * 1.0001)
+                coin.set_exchange_rate(rate, {'from': bob})
+
+        old_virtual_price = swap.get_virtual_price()
+
+        chain.sleep(60)
+
+        # choose which coins to swap
+        send, recv = [int(st_coin.pop() * n_coins) for _ in range(2)]
+        if send == recv:
+            # if send and recv are the same, adjust send
+            send = abs(send - 1)
+
+        value = 5 * rate_mul[send] // st_divisor.pop()
+
+        min_amount = int(0.5 * value * rate_mul[recv] / rate_mul[send])
+        swap.exchange(send, recv, value, min_amount, {'from': bob})
+
+        assert swap.get_virtual_price() >= old_virtual_price

--- a/tests/pools/common/unitary/test_ramp_A.py
+++ b/tests/pools/common/unitary/test_ramp_A.py
@@ -2,7 +2,7 @@ import brownie
 import pytest
 
 pytestmark = pytest.mark.skip_pool(
-    "busd", "compound", "susd", "usdt", "y", "template-base", "template-y"
+    "busd", "compound", "snow", "susd", "usdt", "y", "template-base", "template-y"
 )
 
 MIN_RAMP_TIME = 86400

--- a/tests/pools/common/unitary/test_ramp_A_precise.py
+++ b/tests/pools/common/unitary/test_ramp_A_precise.py
@@ -1,7 +1,7 @@
 import brownie
 import pytest
 
-pytestmark = pytest.mark.target_pool("template-base", "template-y")
+pytestmark = pytest.mark.target_pool("snow", "template-base", "template-y")
 
 MIN_RAMP_TIME = 86400
 

--- a/tests/pools/snow/test_coin_rates.py
+++ b/tests/pools/snow/test_coin_rates.py
@@ -1,0 +1,32 @@
+
+
+def test_initial_assumptions(alice, swap):
+    assert swap.get_coin_rates() == [10**18] * 6
+
+
+def test_modify_wrapped_price(alice, swap, wrapped_coins):
+    rates = [10**18 * i for i in range(5)] + [10**18]
+    for rate, coin in zip(rates, wrapped_coins[:-1]):
+        coin.set_exchange_rate(rate)
+
+    assert swap.get_coin_rates() == rates
+
+
+def test_modify_ycrv_virtual_price(alice, swap, swap_mock):
+    rates = [10**18] * 6
+    rates[4] = int(1.337e18)
+
+    swap_mock._set_virtual_price(rates[4])
+
+    assert swap.get_coin_rates() == rates
+
+
+def test_modify_wrapped_and_ycrv(alice, swap, wrapped_coins, swap_mock):
+    rates = [10**18 * i for i in range(5)] + [10**18]
+    for rate, coin in zip(rates, wrapped_coins[:-1]):
+        coin.set_exchange_rate(rate)
+
+    swap_mock._set_virtual_price(int(1.337e18))
+    rates[4] = rates[4] * int(1.337e18) // 1e18
+
+    assert swap.get_coin_rates() == rates

--- a/tests/pools/snow/test_rate_caching.py
+++ b/tests/pools/snow/test_rate_caching.py
@@ -1,0 +1,83 @@
+import pytest
+
+
+pytestmark = pytest.mark.usefixtures("add_initial_liquidity", "mint_bob", "approve_bob")
+
+
+def test_initial_assumptions(alice, swap):
+    assert swap.get_coin_rates() == [10**18] * 6
+
+
+def test_get_coin_rates_caching(chain, alice, swap, wrapped_coins):
+    rates = [10**18 * (1 + i/100) for i in range(1, 6)] + [10**18]
+    for rate, coin in zip(rates, wrapped_coins[:-1]):
+        coin.set_exchange_rate(rate)
+
+    # modified rates should not take effect immediately
+    assert swap.get_coin_rates() == [10**18] * 6
+
+    chain.sleep(601)
+    chain.mine()
+
+    # 10 minutes later, they should be visible
+    assert swap.get_coin_rates() == rates
+
+
+def test_add_liquidity(chain, bob, swap, wrapped_coins, wrapped_decimals):
+    amounts = [10**i for i in wrapped_decimals]
+
+    rates = [10**18 * (1 + i/100) for i in range(1, 6)] + [10**18]
+    for rate, coin in zip(rates, wrapped_coins[:-1]):
+        coin.set_exchange_rate(rate)
+
+    swap.add_liquidity(amounts, 0, {'from': bob})
+    assert swap.get_coin_rates() == [10**18] * 6
+
+    chain.sleep(601)
+
+    swap.add_liquidity(amounts, 0, {'from': bob})
+    assert swap.get_coin_rates() == rates
+
+
+def test_exchange(chain, bob, swap, wrapped_coins, wrapped_decimals):
+    rates = [10**18 * (1 + i/100) for i in range(1, 6)] + [10**18]
+    for rate, coin in zip(rates, wrapped_coins[:-1]):
+        coin.set_exchange_rate(rate)
+
+    swap.exchange(0, 1, 10**18, 0, {'from': bob})
+    assert swap.get_coin_rates() == [10**18] * 6
+
+    chain.sleep(601)
+
+    swap.exchange(0, 1, 10**18, 0, {'from': bob})
+    assert swap.get_coin_rates() == rates
+
+
+def test_remove_liquidity_imbalance(chain, alice, swap, wrapped_coins, wrapped_decimals):
+    amounts = [10**i for i in wrapped_decimals]
+
+    rates = [10**18 * (1 + i/100) for i in range(1, 6)] + [10**18]
+    for rate, coin in zip(rates, wrapped_coins[:-1]):
+        coin.set_exchange_rate(rate)
+
+    swap.remove_liquidity_imbalance(amounts, 2**256-1, {'from': alice})
+    assert swap.get_coin_rates() == [10**18] * 6
+
+    chain.sleep(601)
+
+    swap.remove_liquidity_imbalance(amounts, 2**256-1, {'from': alice})
+    assert swap.get_coin_rates() == rates
+
+
+def test_remove_liquidity_one_coin(chain, alice, swap, wrapped_coins):
+    rates = [10**18 * (1 + i/100) for i in range(1, 6)] + [10**18]
+    for rate, coin in zip(rates, wrapped_coins[:-1]):
+        coin.set_exchange_rate(rate)
+
+    swap.remove_liquidity_one_coin(10**18, 0, 0, {'from': alice})
+    assert swap.get_coin_rates() == [10**18] * 6
+
+    chain.sleep(601)
+
+    swap.remove_liquidity_one_coin(10**18, 0, 0, {'from': alice})
+    assert swap.get_coin_rates() == rates


### PR DESCRIPTION
### What I did
Add snow pool :snowflake: for swaps between yearn vault tokens. Coins in this pool:

* `yvDAI`: [0xACd43E627e64355f1861cEC6d3a6688B31a6F952](https://etherscan.io/address/0xACd43E627e64355f1861cEC6d3a6688B31a6F952)
* `yvUSDC`: [0x597aD1e0c13Bfe8025993D9e79C69E1c0233522e](https://etherscan.io/address/0x597aD1e0c13Bfe8025993D9e79C69E1c0233522e)
* `yvUSDT`: [0x2f08119C6f07c006695E079AAFc638b8789FAf18](https://etherscan.io/address/0x2f08119C6f07c006695E079AAFc638b8789FAf18)
* `yvTUSD`: [0x37d19d1c4E1fa9DC47bD1eA12f742a0887eDa74a](https://etherscan.io/address/0x37d19d1c4E1fa9DC47bD1eA12f742a0887eDa74a)
* `yvyCRV`: [0x5dbcF33D8c2E976c6b560249878e6F1491Bca25c](https://etherscan.io/address/0x5dbcF33D8c2E976c6b560249878e6F1491Bca25c)
* `USDC`: [0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48](https://etherscan.io/address/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48)

### How I did it
* There is no concept of underlying coins - swaps of the base pairs would be too inefficient due to withdrawal fees on vault tokens.
* The deposit contract has been optimized for this pool. `USE_LENDING` was removed in favor of a hardcoded check.
* Because the value of `ycyCRV` tracks `yCRV`, there is additional logic in calculating the rate for this coin.
* Rates are cached and updated every 10 minutes to reduce gas costs in swaps. Cached values are exposed via the public getter method `coin_rates`.
* Increased precision logic is used for ramping A (#37) 
