### PR TITLE
Mainnet fork test compatibility, gas profiling

### DIFF
--- a/brownie-config.yaml
+++ b/brownie-config.yaml
@@ -11,3 +11,5 @@ hypothesis:
     generate: true
     target: false
     shrink: false
+
+autofetch_sources: true

--- a/contracts/pools/3pool/pooldata.json
+++ b/contracts/pools/3pool/pooldata.json
@@ -1,8 +1,27 @@
 {
     "lp_contract": "CurveTokenV2",
     "coins": [
-        {"decimals": 18, "tethered": false, "wrapped": false},
-        {"decimals": 6, "tethered": false, "wrapped": false},
-        {"decimals": 6, "tethered": true, "wrapped": false}
+        {
+            "name": "DAI",
+            "decimals": 18,
+            "tethered": false,
+            "wrapped": false,
+            "underlying_address": "0x6b175474e89094c44da98b954eedeac495271d0f"
+        },
+        {
+            "name": "USDC",
+            "decimals": 6,
+            "tethered": false,
+            "wrapped": false,
+            "underlying_address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+
+        },
+        {
+            "name": "USDT",
+            "decimals": 6,
+            "tethered": true,
+            "wrapped": false,
+            "underlying_address": "0xdac17f958d2ee523a2206206994597c13d831ec7"
+        }
     ]
 }

--- a/contracts/pools/README.md
+++ b/contracts/pools/README.md
@@ -28,15 +28,20 @@ Each subdirectory holds contracts and other files specific to a single Curve poo
 
 ```js
 {
-    "lp_contract": "CurveTokenV1", // LP token contract to use with this pool, from `contracts/tokens`
-    "wrapped_contract": "yERC20",  // mock wrapped coin contract to use, from `contracts/testing`
-    "coins": [                     // each list item represents 1 swappable coin within the pool
+    "lp_contract": "CurveTokenV1",       // LP token contract to use with this pool, from `contracts/tokens`
+    "wrapped_contract": "yERC20",        // mock wrapped coin contract to use, from `contracts/testing`
+    "coins": [                           // each list item represents 1 swappable coin within the pool
         {
-            "decimals": 18,         // number of decimal places for the underlying coin
-            "tethered": false,      // does the token contract return `None` on a successful transfer/approve?
-            "wrapped": true,        // is wrapping used for this coin?
-            "wrapped_decimals": 18, // decimal places for the wrapped coin - can be omitted if wrapped == false
-            "withdrawal_fee": 0     // optional fee when converting wrapped to underlying, expressed in bps
+            // required fields
+            "decimals": 18,               // number of decimal places for the underlying coin
+            "tethered": false,            // does the token contract return `None` on a successful transfer/approve?
+            "wrapped": true,              // is wrapping used for this coin?
+            "wrapped_decimals": 18,       // decimal places for the wrapped coin - can be omitted if wrapped == false
+            // optional fields
+            "name": "",                   // underlying coin name
+            "withdrawal_fee": 0,          // fee applied when converting wrapped to underlying, expressed in bps
+            "underlying_address": "0x00", // underlying coin mainnet deployment address, used in forked tests
+            "wrapped_address": "0x00"     // wrapped coin mainnet deployment address
         },
     ]
 }

--- a/contracts/pools/busd/pooldata.json
+++ b/contracts/pools/busd/pooldata.json
@@ -2,9 +2,41 @@
     "lp_contract": "CurveTokenV1",
     "wrapped_contract": "yERC20",
     "coins": [
-        {"decimals": 18, "tethered": false, "wrapped": true, "wrapped_decimals": 18},
-        {"decimals": 6, "tethered": false, "wrapped": true, "wrapped_decimals": 6},
-        {"decimals": 6, "tethered": true, "wrapped": true, "wrapped_decimals": 6},
-        {"decimals": 18, "tethered": false, "wrapped": true, "wrapped_decimals": 18}
+        {
+            "name": "DAI",
+            "decimals": 18,
+            "tethered": false,
+            "wrapped": true,
+            "wrapped_decimals": 18,
+            "underlying_address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+            "wrapped_address": "0xc2cb1040220768554cf699b0d863a3cd4324ce32"
+        },
+        {
+            "name": "USDC",
+            "decimals": 6,
+            "tethered": false,
+            "wrapped": true,
+            "wrapped_decimals": 6,
+            "underlying_address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "wrapped_address": "0x26ea744e5b887e5205727f55dfbe8685e3b21951"
+        },
+        {
+            "name": "USDT",
+            "decimals": 6,
+            "tethered": true,
+            "wrapped": true,
+            "wrapped_decimals": 6,
+            "underlying_address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+            "wrapped_address": "0xe6354ed5bc4b393a5aad09f21c46e101e692d447"
+        },
+        {
+            "name": "BUSD",
+            "decimals": 18,
+            "tethered": false,
+            "wrapped": true,
+            "wrapped_decimals": 18,
+            "underlying_address": "0x4fabb145d64652a948d72533023f6e7a623c7c53",
+            "wrapped_address": "0x04bc0ab673d88ae9dbc9da2380cb6b79c4bca9ae"
+        }
     ]
 }

--- a/contracts/pools/compound/pooldata.json
+++ b/contracts/pools/compound/pooldata.json
@@ -2,7 +2,21 @@
     "lp_contract": "CurveTokenV1",
     "wrapped_contract": "cERC20",
     "coins": [
-        {"decimals": 18, "tethered": false, "wrapped": true, "wrapped_decimals": 18},
-        {"decimals": 6, "tethered": false, "wrapped": true, "wrapped_decimals": 6}
+        {
+            "decimals": 18,
+            "tethered": false,
+            "wrapped": true,
+            "wrapped_decimals": 18,
+            "underlying_address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+            "wrapped_address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643"
+        },
+        {
+            "decimals": 6,
+            "tethered": false,
+            "wrapped": true,
+            "wrapped_decimals": 6,
+            "underlying_address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "wrapped_address": "0x39aa39c021dfbae8fac545936693ac917d5e7563"
+        }
     ]
 }

--- a/contracts/pools/hbtc/pooldata.json
+++ b/contracts/pools/hbtc/pooldata.json
@@ -1,7 +1,19 @@
 {
     "lp_contract": "CurveTokenV2",
     "coins": [
-        {"decimals": 18, "tethered": false, "wrapped": false},
-        {"decimals": 8, "tethered": false, "wrapped": false}
+        {
+            "name": "hBTC",
+            "decimals": 18,
+            "tethered": false,
+            "wrapped": false,
+            "underlying_address": "0x0316EB71485b0Ab14103307bf65a021042c6d380"
+        },
+        {
+            "name": "wBTC",
+            "decimals": 8,
+            "tethered": false,
+            "wrapped": false,
+            "underlying_address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599"
+        }
     ]
 }

--- a/contracts/pools/pax/pooldata.json
+++ b/contracts/pools/pax/pooldata.json
@@ -2,9 +2,35 @@
     "lp_contract": "CurveTokenV1",
     "wrapped_contract": "yERC20",
     "coins": [
-        {"decimals": 18, "tethered": false, "wrapped": true, "wrapped_decimals": 18},
-        {"decimals": 6, "tethered": false, "wrapped": true, "wrapped_decimals": 6},
-        {"decimals": 6, "tethered": true, "wrapped": true, "wrapped_decimals": 6},
-        {"decimals": 18, "tethered": false, "wrapped": false}
+        {
+            "decimals": 18,
+            "tethered": false,
+            "wrapped": true,
+            "wrapped_decimals": 18,
+            "underlying_address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+            "wrapped_address": "0x99d1fa417f94dcd62bfe781a1213c092a47041bc"
+        },
+        {
+            "decimals": 6,
+            "tethered": false,
+            "wrapped": true,
+            "wrapped_decimals": 6,
+            "underlying_address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "wrapped_address": "0x9777d7e2b60bb01759d0e2f8be2095df444cb07e"
+        },
+        {
+            "decimals": 6,
+            "tethered": true,
+            "wrapped": true,
+            "wrapped_decimals": 6,
+            "underlying_address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+            "wrapped_address": "0x1be5d71f2da660bfdee8012ddc58d024448a0a59"
+        },
+        {
+            "decimals": 18,
+            "tethered": false,
+            "wrapped": false,
+            "underlying_address": "0x8e870d67f660d95d5be530380d0ec0bd388289e1"
+        }
     ]
 }

--- a/contracts/pools/ren/pooldata.json
+++ b/contracts/pools/ren/pooldata.json
@@ -2,7 +2,19 @@
     "lp_contract": "CurveTokenV1",
     "wrapped_contract": "renERC20",
     "coins": [
-        {"decimals": 8, "tethered": false, "wrapped": true, "wrapped_decimals": 8},
-        {"decimals": 8, "tethered": false, "wrapped": false}
+        {
+            "decimals": 8,
+            "tethered": false,
+            "wrapped": true,
+            "wrapped_decimals": 8,
+            "underlying_address": "0xeb4c2781e4eba804ce9a9803c67d0893436bb27d",
+            "wrapped_address": "0xeb4c2781e4eba804ce9a9803c67d0893436bb27d"
+        },
+        {
+            "decimals": 8,
+            "tethered": false,
+            "wrapped": false,
+            "underlying_address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599"
+        }
     ]
 }

--- a/contracts/pools/sbtc/pooldata.json
+++ b/contracts/pools/sbtc/pooldata.json
@@ -2,8 +2,25 @@
     "lp_contract": "CurveTokenV1",
     "wrapped_contract": "renERC20",
     "coins": [
-        {"decimals": 8, "tethered": false, "wrapped": true, "wrapped_decimals": 8},
-        {"decimals": 8, "tethered": false, "wrapped": false},
-        {"decimals": 18, "tethered": false, "wrapped": false}
+        {
+            "decimals": 8,
+            "tethered": false,
+            "wrapped": true,
+            "wrapped_decimals": 8,
+            "underlying_address": "0xeb4c2781e4eba804ce9a9803c67d0893436bb27d",
+            "wrapped_address": "0xeb4c2781e4eba804ce9a9803c67d0893436bb27d"
+        },
+        {
+            "decimals": 8,
+            "tethered": false,
+            "wrapped": false,
+            "underlying_address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599"
+        },
+        {
+            "decimals": 18,
+            "tethered": false,
+            "wrapped": false,
+            "underlying_address": "0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6"
+        }
     ]
 }

--- a/contracts/pools/snow/pooldata.json
+++ b/contracts/pools/snow/pooldata.json
@@ -1,13 +1,63 @@
 {
-
     "lp_contract": "CurveTokenV2",
     "wrapped_contract": "yERC20",
     "coins": [
-        {"decimals": 18, "tethered": false, "wrapped": true, "wrapped_decimals": 18, "withdrawal_fee": 500},
-        {"decimals": 6, "tethered": false, "wrapped": true, "wrapped_decimals": 6, "withdrawal_fee": 500},
-        {"decimals": 6, "tethered": true, "wrapped": true, "wrapped_decimals": 6, "withdrawal_fee": 500},
-        {"decimals": 18, "tethered": false, "wrapped": true, "wrapped_decimals": 18, "withdrawal_fee": 500},
-        {"decimals": 18, "tethered": false, "wrapped": true, "wrapped_decimals": 18, "withdrawal_fee": 500},
-        {"decimals": 6, "tethered": false, "wrapped": false}
+        {
+            "name": "DAI",
+            "decimals": 18,
+            "tethered": false,
+            "wrapped": true,
+            "wrapped_decimals": 18,
+            "withdrawal_fee": 500,
+            "underlying_address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+            "wrapped_address": "0xACd43E627e64355f1861cEC6d3a6688B31a6F952"
+        },
+        {
+            "name": "USDC",
+            "decimals": 6,
+            "tethered": false,
+            "wrapped": true,
+            "wrapped_decimals": 6,
+            "withdrawal_fee": 500,
+            "underlying_address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "wrapped_address": "0x597aD1e0c13Bfe8025993D9e79C69E1c0233522e"
+        },
+        {
+            "name": "USDT",
+            "decimals": 6,
+            "tethered": true,
+            "wrapped": true,
+            "wrapped_decimals": 6,
+            "withdrawal_fee": 500,
+            "underlying_address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+            "wrapped_address": "0x2f08119C6f07c006695E079AAFc638b8789FAf18"
+        },
+        {
+            "name": "TUSD",
+            "decimals": 18,
+            "tethered": false,
+            "wrapped": true,
+            "wrapped_decimals": 18,
+            "withdrawal_fee": 500,
+            "underlying_address": "0x0000000000085d4780b73119b644ae5ecd22b376",
+            "wrapped_address": "0x37d19d1c4E1fa9DC47bD1eA12f742a0887eDa74a"
+        },
+        {
+            "name": "yCRV",
+            "decimals": 18,
+            "tethered": false,
+            "wrapped": true,
+            "wrapped_decimals": 18,
+            "withdrawal_fee": 500,
+            "underlying_address": "0xdF5e0e81Dff6FAF3A7e52BA697820c5e32D806A8",
+            "wrapped_address": "0x5dbcF33D8c2E976c6b560249878e6F1491Bca25c"
+        },
+        {
+            "name": "USDC",
+            "decimals": 6,
+            "tethered": false,
+            "wrapped": false,
+            "underlying_address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        }
     ]
 }

--- a/contracts/pools/susd/pooldata.json
+++ b/contracts/pools/susd/pooldata.json
@@ -1,9 +1,33 @@
 {
     "lp_contract": "CurveTokenV1",
     "coins": [
-        {"decimals": 18, "tethered": false, "wrapped": false},
-        {"decimals": 6, "tethered": false, "wrapped": false},
-        {"decimals": 6, "tethered": true, "wrapped": false},
-        {"decimals": 18, "tethered": false, "wrapped": false}
+        {
+            "name": "DAI",
+            "decimals": 18,
+            "tethered": false,
+            "wrapped": false,
+            "underlying_address": "0x6b175474e89094c44da98b954eedeac495271d0f"
+        },
+        {
+            "name": "USDC",
+            "decimals": 6,
+            "tethered": false,
+            "wrapped": false,
+            "underlying_address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        },
+        {
+            "name": "USDT",
+            "decimals": 6,
+            "tethered": true,
+            "wrapped": false,
+            "underlying_address": "0xdac17f958d2ee523a2206206994597c13d831ec7"
+        },
+        {
+            "name": "SUSD",
+            "decimals": 18,
+            "tethered": false,
+            "wrapped": false,
+            "underlying_address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51"
+        }
     ]
 }

--- a/contracts/pools/usdt/pooldata.json
+++ b/contracts/pools/usdt/pooldata.json
@@ -2,8 +2,30 @@
     "lp_contract": "CurveTokenV1",
     "wrapped_contract": "cERC20",
     "coins": [
-        {"decimals": 18, "tethered": false, "wrapped": true, "wrapped_decimals": 18},
-        {"decimals": 6, "tethered": false, "wrapped": true, "wrapped_decimals": 6},
-        {"decimals": 6, "tethered": true, "wrapped": false}
+        {
+            "name": "DAI",
+            "decimals": 18,
+            "tethered": false,
+            "wrapped": true,
+            "wrapped_decimals": 18,
+            "underlying_address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+            "wrapped_address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643"
+        },
+        {
+            "name": "USDC",
+            "decimals": 6,
+            "tethered": false,
+            "wrapped": true,
+            "wrapped_decimals": 6,
+            "underlying_address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "wrapped_address": "0x39aa39c021dfbae8fac545936693ac917d5e7563"
+        },
+        {
+            "name": "USDT",
+            "decimals": 6,
+            "tethered": true,
+            "wrapped": false,
+            "underlying_address": "0xdac17f958d2ee523a2206206994597c13d831ec7"
+        }
     ]
 }

--- a/contracts/pools/y/pooldata.json
+++ b/contracts/pools/y/pooldata.json
@@ -1,11 +1,42 @@
 {
-
     "lp_contract": "CurveTokenV1",
     "wrapped_contract": "yERC20",
     "coins": [
-        {"decimals": 18, "tethered": false, "wrapped": true, "wrapped_decimals": 18},
-        {"decimals": 6, "tethered": false, "wrapped": true, "wrapped_decimals": 6},
-        {"decimals": 6, "tethered": true, "wrapped": true, "wrapped_decimals": 6},
-        {"decimals": 18, "tethered": false, "wrapped": true, "wrapped_decimals": 18}
+        {
+            "name": "DAI",
+            "decimals": 18,
+            "tethered": false,
+            "wrapped": true,
+            "wrapped_decimals": 18,
+            "underlying_address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+            "wrapped_address": "0xc2cb1040220768554cf699b0d863a3cd4324ce32"
+        },
+        {
+            "name": "USDC",
+            "decimals": 6,
+            "tethered": false,
+            "wrapped": true,
+            "wrapped_decimals": 6,
+            "underlying_address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "wrapped_address": "0x26ea744e5b887e5205727f55dfbe8685e3b21951"
+        },
+        {
+            "name": "USDT",
+            "decimals": 6,
+            "tethered": true,
+            "wrapped": true,
+            "wrapped_decimals": 6,
+            "underlying_address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+            "wrapped_address": "0xe6354ed5bc4b393a5aad09f21c46e101e692d447"
+        },
+        {
+            "name": "TUSD",
+            "decimals": 18,
+            "tethered": false,
+            "wrapped": true,
+            "wrapped_decimals": 18,
+            "underlying_address": "0x0000000000085d4780b73119b644ae5ecd22b376",
+            "wrapped_address": "0x73a052500105205d34daf004eab301916da8190f"
+        }
     ]
 }

--- a/contracts/testing/ERC20Mock.vy
+++ b/contracts/testing/ERC20Mock.vy
@@ -65,7 +65,9 @@ def approve(_spender : address, _value : uint256) -> bool:
 
 
 @external
-def _mint_for_testing(_target: address, _value: uint256):
+def _mint_for_testing(_target: address, _value: uint256) -> bool:
     self.total_supply += _value
     self.balanceOf[_target] += _value
     log Transfer(ZERO_ADDRESS, _target, _value)
+
+    return True

--- a/contracts/testing/ERC20MockNoReturn.vy
+++ b/contracts/testing/ERC20MockNoReturn.vy
@@ -64,7 +64,9 @@ def approve(_spender : address, _value : uint256):
 
 
 @external
-def _mint_for_testing(_target: address, _value: uint256):
+def _mint_for_testing(_target: address, _value: uint256) -> bool:
     self.total_supply += _value
     self.balanceOf[_target] += _value
     log Transfer(ZERO_ADDRESS, _target, _value)
+
+    return True

--- a/contracts/testing/README.md
+++ b/contracts/testing/README.md
@@ -20,8 +20,10 @@ Contracts used exclusively for testing. These are not considered part of Curve a
 All test tokens implement the following method to allow minting to arbitrary addresses during testing:
 
 ```python
-def _mint_for_testing(_target: address, _value: uint256):
+def _mint_for_testing(_target: address, _value: uint256) -> bool:
 ```
 
 * `_target`: Address to mint tokens to
 * `_value`: Number of tokens to mint
+
+When called on a wrapped token, an amount of the underlying token is also minted at the wrapped token address in order to ensure unwrapping is possible.

--- a/contracts/testing/cERC20.vy
+++ b/contracts/testing/cERC20.vy
@@ -6,6 +6,11 @@
 
 from vyper.interfaces import ERC20
 
+interface ERC20Mock:
+    def decimals() -> uint256: view
+    def _mint_for_testing(_target: address, _value: uint256) -> bool: nonpayable
+
+
 event Transfer:
     _from: indexed(address)
     _to: indexed(address)
@@ -169,7 +174,12 @@ def exchangeRateCurrent() -> uint256:
 
 
 @external
-def _mint_for_testing(_target: address, _value: uint256):
+def _mint_for_testing(_target: address, _value: uint256) -> bool:
+    _udecimals: uint256 = ERC20Mock(self.underlying_token).decimals()
+    _underlying_value: uint256 = 2 * _value * 10 ** _udecimals / 10 ** self.decimals
+    ERC20Mock(self.underlying_token)._mint_for_testing(self, _underlying_value)
     self.total_supply += _value
     self.balanceOf[_target] += _value
     log Transfer(ZERO_ADDRESS, _target, _value)
+
+    return True

--- a/contracts/testing/renERC20.vy
+++ b/contracts/testing/renERC20.vy
@@ -6,6 +6,11 @@
 
 from vyper.interfaces import ERC20
 
+interface ERC20Mock:
+    def decimals() -> uint256: view
+    def _mint_for_testing(_target: address, _value: uint256) -> bool: nonpayable
+
+
 event Transfer:
     _from: indexed(address)
     _to: indexed(address)
@@ -168,7 +173,12 @@ def exchangeRateCurrent() -> uint256:
 
 
 @external
-def _mint_for_testing(_target: address, _value: uint256):
+def _mint_for_testing(_target: address, _value: uint256) -> bool:
+    _udecimals: uint256 = ERC20Mock(self.underlying_token).decimals()
+    _underlying_value: uint256 = 2 * _value * 10 ** _udecimals / 10 ** self.decimals
+    ERC20Mock(self.underlying_token)._mint_for_testing(self, _underlying_value)
     self.total_supply += _value
     self.balanceOf[_target] += _value
     log Transfer(ZERO_ADDRESS, _target, _value)
+
+    return True

--- a/contracts/testing/yERC20.vy
+++ b/contracts/testing/yERC20.vy
@@ -7,6 +7,11 @@
 
 from vyper.interfaces import ERC20
 
+interface ERC20Mock:
+    def decimals() -> uint256: view
+    def _mint_for_testing(_target: address, _value: uint256) -> bool: nonpayable
+
+
 event Transfer:
     _from: indexed(address)
     _to: indexed(address)
@@ -141,7 +146,12 @@ def _set_withdrawal_fee(pct: uint256):
 
 
 @external
-def _mint_for_testing(_target: address, _value: uint256):
+def _mint_for_testing(_target: address, _value: uint256) -> bool:
+    _udecimals: uint256 = ERC20Mock(self.underlying_token).decimals()
+    _underlying_value: uint256 = 2 * _value * 10 ** _udecimals / 10 ** self.decimals
+    ERC20Mock(self.underlying_token)._mint_for_testing(self, _underlying_value)
     self.total_supply += _value
     self.balanceOf[_target] += _value
     log Transfer(ZERO_ADDRESS, _target, _value)
+
+    return True

--- a/tests/README.md
+++ b/tests/README.md
@@ -38,6 +38,16 @@ To run against one of the templates, use `template-base` or `template-y`.
 
 You can optionally include the `--coverage` flag to view a coverage report upon completion of the tests.
 
+## Testing against a forked mainnet
+
+To run the test suite against a forked mainnet:
+
+```bash
+brownie test --network mainnet-fork
+```
+
+In this mode, the actual underlying and wrapped coins are used for testing. Note that forked mode can be _very slow_, especially if you are running against a public node.
+
 ## Fixtures
 
 Test fixtures are located within the [`tests/fixtures`](fixtures) subdirectory. New fixtures should be added here instead of within the base [`conftest.py`](conftest.py).
@@ -74,6 +84,16 @@ Only run the given test against pools that involve lending.
 ```python
 @pytest.mark.lending
 def test_underlying(swap):
+    ...
+```
+
+### `zap`
+
+Only run the given test against pools that use a deposit contract.
+
+```python
+@pytest.mark.zap
+def test_deposits(zap):
     ...
 ```
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,7 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "target_pool: run test against one or more specific pool")
     config.addinivalue_line("markers", "skip_pool: exclude one or more pools in this test")
     config.addinivalue_line("markers", "lending: only run test against pools that involve lending")
+    config.addinivalue_line("markers", "zap: only run test against pools with a deposit contract")
     config.addinivalue_line(
         "markers",
         "itercoins: parametrize a test with one or more ranges, equal to the length "
@@ -106,7 +107,17 @@ def pytest_generate_tests(metafunc):
             else:
                 # run targetted pool/zap tests against only the specific pool
                 params = [test_path.parts[2]]
-            metafunc.parametrize("pool_data", params, indirect=True, scope="session")
+        else:
+            # pool tests outside `tests/pools` or `tests/zaps` will only run when
+            # a target pool is explicitly declared
+            try:
+                params = metafunc.config.getoption("pool").split(',')
+            except Exception:
+                raise pytest.UsageError(
+                    f"'{test_path.as_posix()}' contains pool tests, but is outside of "
+                    "'tests/pools/'. To run it, specify a pool with `--pool [name]`"
+                )
+        metafunc.parametrize("pool_data", params, indirect=True, scope="session")
 
         # apply initial parametrization of `itercoins`
         for marker in metafunc.definition.iter_markers(name="itercoins"):
@@ -147,6 +158,11 @@ def pytest_collection_modifyitems(config, items):
         for marker in item.iter_markers(name="lending"):
             deployer = getattr(project, data['swap_contract'])
             if "exchange_underlying" not in deployer.signatures:
+                items.remove(item)
+
+        # apply `lending` marker
+        for marker in item.iter_markers(name="zap"):
+            if "zap_contract" not in data:
                 items.remove(item)
 
     # hacky magic to ensure the correct number of tests is shown in collection report

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -10,7 +10,6 @@ Pytest fixtures used in Curve's test suite.
 * [`pooldata.py`](pooldata.py): Pool dependent data fixtures
 * [`setup.py`](setup.py): Test setup fixtures, used for common processes such as adding initial liquidity or approving token transfers
 
-
 ## Fixtures
 
 ### `accounts.py`

--- a/tests/fixtures/deployments.py
+++ b/tests/fixtures/deployments.py
@@ -78,8 +78,11 @@ def swap(project, alice, underlying_coins, wrapped_coins, pool_token, pool_data,
 
 @pytest.fixture(scope="module")
 def zap(project, alice, swap, underlying_coins, wrapped_coins, pool_token, pool_data):
-    deployer = getattr(project, pool_data['zap_contract'])
-    yield deployer.deploy(wrapped_coins, underlying_coins, swap, pool_token, {'from': alice})
+    deployer = getattr(project, pool_data.get('zap_contract'), None)
+    if deployer is None:
+        yield False
+    else:
+        yield deployer.deploy(wrapped_coins, underlying_coins, swap, pool_token, {'from': alice})
 
 
 @pytest.fixture(scope="module")

--- a/tests/fixtures/setup.py
+++ b/tests/fixtures/setup.py
@@ -18,9 +18,9 @@ def mint_bob(bob, underlying_coins, wrapped_coins, initial_amounts):
             continue
 
         if underlying != wrapped:
-            underlying._mint_for_testing(bob, amount * 2, {'from': bob})
-            underlying.approve(wrapped, 2**256-1, {'from': bob})
-            wrapped.mint(amount, {'from': bob})
+            wrapped._mint_for_testing(bob, amount, {'from': bob})
+            amount = amount * 10 ** wrapped.decimals() / 10 ** underlying.decimals()
+            underlying._mint_for_testing(bob, amount, {'from': bob})
         else:
             underlying._mint_for_testing(bob, amount, {'from': bob})
 
@@ -42,9 +42,9 @@ def mint_alice(alice, underlying_coins, wrapped_coins, initial_amounts):
             continue
 
         if underlying != wrapped:
-            underlying._mint_for_testing(alice, amount * 2, {'from': alice})
-            underlying.approve(wrapped, 2**256-1, {'from': alice})
-            wrapped.mint(amount, {'from': alice})
+            wrapped._mint_for_testing(alice, amount, {'from': alice})
+            amount = amount * 10 ** wrapped.decimals() / 10 ** underlying.decimals()
+            underlying._mint_for_testing(alice, amount, {'from': alice})
         else:
             underlying._mint_for_testing(alice, amount, {'from': alice})
 

--- a/tests/pools/common/integration/test_registry.py
+++ b/tests/pools/common/integration/test_registry.py
@@ -28,29 +28,31 @@ def test_amount_dy_underlying(registry, swap, send, recv):
 
 
 @pytest.mark.itercoins("send", "recv")
-def test_exchange(bob, registry, wrapped_coins, swap, send, recv):
+def test_exchange(bob, registry, wrapped_coins, wrapped_decimals, swap, send, recv):
     send_token = wrapped_coins[send]
     recv_token = wrapped_coins[recv]
 
-    send_token._mint_for_testing(bob, 10**18, {'from': bob})
-    send_token.approve(registry, 10**18, {'from': bob})
-    expected = registry.get_exchange_amount(swap, send_token, recv_token, 10**18)
+    amount = 10**wrapped_decimals[send]
+    send_token._mint_for_testing(bob, amount, {'from': bob})
+    send_token.approve(registry, amount, {'from': bob})
+    expected = registry.get_exchange_amount(swap, send_token, recv_token, amount)
 
-    registry.exchange(swap, send_token, recv_token, 10**18, 0, {'from': bob})
+    registry.exchange(swap, send_token, recv_token, amount, 0, {'from': bob})
     assert send_token.balanceOf(bob) == 0
     assert recv_token.balanceOf(bob) / expected == pytest.approx(1)
 
 
 @pytest.mark.lending
 @pytest.mark.itercoins("send", "recv")
-def test_exchange_underlying(bob, registry, underlying_coins, swap, send, recv):
+def test_exchange_underlying(bob, registry, underlying_coins, underlying_decimals, swap, send, recv):
     send_token = underlying_coins[send]
     recv_token = underlying_coins[recv]
 
-    send_token._mint_for_testing(bob, 10**18, {'from': bob})
-    send_token.approve(registry, 10**18, {'from': bob})
-    expected = registry.get_exchange_amount(swap, send_token, recv_token, 10**18)
+    amount = 10**underlying_decimals[send]
+    send_token._mint_for_testing(bob, amount, {'from': bob})
+    send_token.approve(registry, amount, {'from': bob})
+    expected = registry.get_exchange_amount(swap, send_token, recv_token, amount)
 
-    registry.exchange(swap, send_token, recv_token, 10**18, 0, {'from': bob})
+    registry.exchange(swap, send_token, recv_token, amount, 0, {'from': bob})
     assert send_token.balanceOf(bob) == 0
     assert recv_token.balanceOf(bob) / expected == pytest.approx(1)

--- a/tests/test_gas.py
+++ b/tests/test_gas.py
@@ -1,0 +1,53 @@
+import itertools
+import pytest
+
+pytestmark = pytest.mark.usefixtures("mint_alice", "approve_alice", "mint_bob", "approve_bob")
+
+
+def test_swap_gas(chain, alice, bob, swap, n_coins, wrapped_decimals, initial_amounts):
+    swap.add_liquidity(initial_amounts, 0, {'from': alice})
+    chain.sleep(3600)
+
+    for send, recv in itertools.permutations(range(n_coins), 2):
+        amount = 10**wrapped_decimals[send]
+        swap.exchange(send, recv, amount, 0, {'from': bob})
+        chain.sleep(3600)
+
+    if hasattr(swap, "exchange_underlying"):
+        for send, recv in itertools.permutations(range(n_coins), 2):
+            amount = 10**wrapped_decimals[send]
+            swap.exchange_underlying(send, recv, amount, 0, {'from': bob})
+            chain.sleep(3600)
+
+    swap.remove_liquidity(10**18, [0] * n_coins, {'from': alice})
+    chain.sleep(3600)
+
+    amounts = [10**wrapped_decimals[i] for i in range(n_coins)]
+    swap.remove_liquidity_imbalance(amounts, 2**256-1, {'from': alice})
+    chain.sleep(3600)
+
+    if hasattr(swap, "remove_liquidity_one_coin"):
+        for idx in range(n_coins):
+            swap.remove_liquidity_one_coin(10**wrapped_decimals[idx], idx, 0, {'from': alice})
+            chain.sleep(3600)
+
+
+@pytest.mark.zap
+def test_zap_gas(chain, alice, n_coins, underlying_decimals, initial_amounts, zap, approve_zap):
+    if not zap:
+        return
+
+    zap.add_liquidity(initial_amounts, 0, {'from': alice})
+    chain.sleep(3600)
+
+    zap.remove_liquidity(10**18, [0] * n_coins, {'from': alice})
+    chain.sleep(3600)
+
+    amounts = [10**underlying_decimals[i] for i in range(n_coins)]
+    zap.remove_liquidity_imbalance(amounts, 2**256-1, {'from': alice})
+    chain.sleep(3600)
+
+    if hasattr(zap, "remove_liquidity_one_coin"):
+        for idx in range(n_coins):
+            zap.remove_liquidity_one_coin(10**underlying_decimals[idx], idx, 0, {'from': alice})
+            chain.sleep(3600)

--- a/tests/test_gas.py
+++ b/tests/test_gas.py
@@ -4,7 +4,16 @@ import pytest
 pytestmark = pytest.mark.usefixtures("mint_alice", "approve_alice", "mint_bob", "approve_bob")
 
 
-def test_swap_gas(chain, alice, bob, swap, n_coins, wrapped_decimals, initial_amounts):
+def test_swap_gas(
+    chain,
+    alice,
+    bob,
+    swap,
+    n_coins,
+    wrapped_decimals,
+    underlying_decimals,
+    initial_amounts,
+):
     swap.add_liquidity(initial_amounts, 0, {'from': alice})
     chain.sleep(3600)
 
@@ -15,7 +24,7 @@ def test_swap_gas(chain, alice, bob, swap, n_coins, wrapped_decimals, initial_am
 
     if hasattr(swap, "exchange_underlying"):
         for send, recv in itertools.permutations(range(n_coins), 2):
-            amount = 10**wrapped_decimals[send]
+            amount = 10**underlying_decimals[send]
             swap.exchange_underlying(send, recv, amount, 0, {'from': bob})
             chain.sleep(3600)
 


### PR DESCRIPTION
### What I did
* expand the test suite so it can also be run in `--fork` mode
* add a new test specifically for gas profiling

### How I did it
When the test suite is run in `--fork` mode, the `underlying_coins` and `wrapped_coins` fixtures contain the actual tokens to be traded in a pool. Addresses are obtained from `pooldata.json` for the active pool.  I have created a new class, `MintableTestToken`, which wraps around brownie's `Contract` object. Calling `_mint_for_testing` queries the ethplorer API for a list of the largest token holders. These accounts are then unlocked with Ganache's new `eth_unlockUnknownAccount` RPC call, and the tokens are transferred to the requested address.

A new test module, `tests/test_gas.py` performs a swap between each token and underlying token, and deposits and withdraws using each possible method. The idea is to use this test along with `--fork` mode as both a final verification that the pool works with the given tokens as expected, and to profile expected gas costs.

Note that using this mode requires the latest beta of Ganache (`v6.11.0-beta1`) and Brownie (`v1.11.6`).

### How to verify it
Run the tests.