### PR TITLE
Metapool template

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,7 +14,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pool: [3pool, busd, compound, hbtc, pax, ren, sbtc, snow, susd, template-base, template-y, usdt, y]
+        pool: [
+          3pool,
+          busd,
+          compound,
+          hbtc,
+          pax,
+          ren,
+          sbtc,
+          snow,
+          susd,
+          template-base,
+          template-meta,
+          template-y,
+          usdt,
+          y
+        ]
 
     steps:
     - uses: actions/checkout@v1
@@ -50,7 +65,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pool: [3pool, busd, compound, hbtc, pax, ren, sbtc, snow, susd, template-base, template-y, usdt, y]
+        pool: [
+          3pool,
+          busd,
+          compound,
+          hbtc,
+          pax,
+          ren,
+          sbtc,
+          snow,
+          susd,
+          template-base,
+          template-meta,
+          template-y,
+          usdt,
+          y
+        ]
 
     steps:
     - uses: actions/checkout@v1

--- a/brownie_hooks.py
+++ b/brownie_hooks.py
@@ -8,24 +8,51 @@ This file should not be modified directly. Values are set based on the
 import json
 
 
+def _load_pool_data(path):
+    with path.parent.joinpath('pooldata.json').open() as fp:
+        data = json.load(fp)
+
+    decimals = [i['decimals'] for i in data['coins']]
+    precision_multiplier = [10**18 // (10**i) for i in decimals]
+
+    return {
+        'n_coins': len(decimals),
+        'decimals': decimals,
+        'precision_mul': precision_multiplier,
+        'rates': [i*10**18 for i in precision_multiplier],
+        'lending': [i['wrapped'] for i in data['coins']],
+        'base_pool_contract': data.get("base_pool_contract"),
+    }
+
+
 def brownie_load_source(path, source):
 
     if "pool-templates" not in path.parts:
+        # compile-time substitution only applies to pool templates
         return source
 
-    with path.parent.joinpath('pooldata.json').open() as fp:
-        pool_data = json.load(fp)
-
-    decimals = [i['decimals'] for i in pool_data['coins']]
-    precision_multiplier = [10**18 // (10**i) for i in decimals]
-    rates = [i*10**18 for i in precision_multiplier]
+    data_path = path.parent.joinpath('pooldata.json')
+    pool_data = _load_pool_data(data_path)
 
     replacements = {
-        '___N_COINS___': len(decimals),
-        '___PRECISION_MUL___': precision_multiplier,
-        '___RATES___': rates,
-        '___USE_LENDING___': [i['wrapped'] for i in pool_data['coins']],
+        '___N_COINS___': pool_data['n_coins'],
+        '___PRECISION_MUL___': pool_data['precision_mul'],
+        '___RATES___': pool_data['rates'],
+        '___USE_LENDING___': pool_data['lending'],
     }
+
+    if pool_data["base_pool_contract"]:
+        # for metapools, also load pool data for the base pool
+        contracts_dir = next(i for i in path.parents if i.name == "contracts")
+        swap_dir = next(contracts_dir.glob(f"**/{pool_data['base_pool_contract']}.vy")).parent
+        data_path = swap_dir.joinpath("pooldata.json")
+        pool_data = _load_pool_data(data_path)
+
+        replacements.update({
+            '___BASE_N_COINS___': pool_data['n_coins'],
+            '___BASE_PRECISION_MUL___': pool_data['precision_mul'],
+            '___BASE_RATES___': pool_data['rates'],
+        })
 
     for k, v in replacements.items():
         source = source.replace(k, str(v))

--- a/contracts/pool-templates/README.md
+++ b/contracts/pool-templates/README.md
@@ -7,6 +7,7 @@ Contract templates used as the basis for future pools.
 Each subdirectory holds contracts and other files specific to a single Curve pool template.
 
 * [`base`]: Minimal pool implementation optimized for no lending
+* [`meta`]: Metapool implementation for swapping base assets against a Curve LP token
 * [`y`]: Pool implementation with yearn-style lending
 
 ## Development
@@ -20,6 +21,12 @@ Contracts in this subdirectory contain special triple-dunder variables which are
 * `___PRECISION_MUL___`: Array of integers that coin balances are multiplied by in order to adjust their precision to 18 decimal places
 * `___RATES___`: Array of integers indicating the relative value of `1e18` tokens for each stablecoin
 
+Metapools also make use of the following variables:
+
+* `___BASE_N_COINS___`: The number of coins within the base pool
+* `___BASE_PRECISION_MUL___`: Array of integers that base coin balances are multiplied by to adjust their precision to 18 decimal places
+* `___BASE_RATES___`: Array of integers indicating the relative walue of `1e18` tokens for each base pool stablecoin
+
 These variables are substituted out at compile-time. To set the values, edit the `pooldata.json` file within the template directory.
 
 The layout of a template's `pooldata.json` is similar to that of an actual pool, but less fields are required:
@@ -29,7 +36,6 @@ The layout of a template's `pooldata.json` is similar to that of an actual pool,
     "wrapped_contract": "yERC20",   // mock wrapped coin contract to use, from `contracts/testing`
     "coins": [                      // each list item represents 1 swappable coin within the pool
         {
-            // required fields
             "decimals": 18,          // number of decimal places for the underlying coin
             "tethered": false,       // does the token contract return `None` on a successful transfer/approve?
             "wrapped": true,         // is wrapping used for this coin?

--- a/contracts/pool-templates/meta/DepositTemplateMeta.vy
+++ b/contracts/pool-templates/meta/DepositTemplateMeta.vy
@@ -1,0 +1,218 @@
+# @version 0.2.4
+# (c) Curve.Fi, 2020
+# Deposit zap for the metapool
+#
+# Coins 0 .. N_COINS-2 are normal coins
+# Coin N_COINS-1 is another pool token which has get_virtual_price()
+
+from vyper.interfaces import ERC20
+
+
+interface CurveMeta:
+    def add_liquidity(amounts: uint256[N_COINS], min_mint_amount: uint256): nonpayable
+    def remove_liquidity(_amount: uint256, min_amounts: uint256[N_COINS]): nonpayable
+    def remove_liquidity_one_coin(_token_amount: uint256, i: int128, min_amount: uint256): nonpayable
+    def calc_withdraw_one_coin(_token_amount: uint256, i: int128) -> uint256: view
+    def calc_token_amount(amounts: uint256[N_COINS], deposit: bool) -> uint256: view
+    def base_pool() -> address: view
+    def coins(i: uint256) -> address: view
+
+interface CurveBase:
+    def add_liquidity(amounts: uint256[BASE_N_COINS], min_mint_amount: uint256): nonpayable
+    def remove_liquidity(_amount: uint256, min_amounts: uint256[BASE_N_COINS]): nonpayable
+    def remove_liquidity_one_coin(_token_amount: uint256, i: int128, min_amount: uint256): nonpayable
+    def calc_withdraw_one_coin(_token_amount: uint256, i: int128) -> uint256: view
+    def calc_token_amount(amounts: uint256[BASE_N_COINS], deposit: bool) -> uint256: view
+    def coins(i: uint256) -> address: view
+
+
+N_COINS: constant(int128) = ___N_COINS___
+MAX_COIN: constant(int128) = N_COINS-1
+BASE_N_COINS: constant(int128) = ___BASE_N_COINS___
+N_ALL_COINS: constant(int128) = N_COINS + BASE_N_COINS - 1
+#
+# An asset shich may have a transfer fee (USDT)
+FEE_ASSET: constant(address) = 0xdAC17F958D2ee523a2206206994597C13D831ec7
+
+
+pool: public(address)
+token: public(address)
+base_pool: public(address)
+
+coins: public(address[N_COINS])
+base_coins: public(address[BASE_N_COINS])
+
+
+@external
+def __init__(_pool: address, _token: address):
+    self.pool = _pool
+    self.token = _token
+    _base_pool: address = CurveMeta(_pool).base_pool()
+    self.base_pool = _base_pool
+
+    for i in range(N_COINS):
+        coin: address = CurveMeta(_pool).coins(convert(i, uint256))
+        self.coins[i] = coin
+        ERC20(coin).approve(_pool, MAX_UINT256)
+
+    for i in range(BASE_N_COINS):
+        coin: address = CurveBase(_base_pool).coins(convert(i, uint256))
+        self.base_coins[i] = coin
+        ERC20(coin).approve(self, MAX_UINT256)
+
+
+@external
+@nonreentrant('lock')
+def add_liquidity(amounts: uint256[N_ALL_COINS], min_mint_amount: uint256):
+    meta_amounts: uint256[N_COINS] = empty(uint256[N_COINS])  # Ben, Bryant, - wen slicing? :-D
+    for i in range(MAX_COIN):
+        meta_amounts[i] = amounts[i]
+    base_amounts: uint256[BASE_N_COINS] = empty(uint256[BASE_N_COINS])
+    for i in range(BASE_N_COINS):
+        base_amounts[i] = amounts[i + MAX_COIN]
+
+    # Transfer all coins in
+    for i in range(N_ALL_COINS):
+        coin: address = ZERO_ADDRESS
+        if i < MAX_COIN:
+            coin = self.coins[i]
+        else:
+            coin = self.base_coins[i - MAX_COIN]
+        # "safeTransferFrom" which works for ERC20s which return bool or not
+        _response: Bytes[32] = raw_call(
+            coin,
+            concat(
+                method_id("transferFrom(address,address,uint256)"),
+                convert(msg.sender, bytes32),
+                convert(self, bytes32),
+                convert(amounts[i], bytes32),
+            ),
+            max_outsize=32,
+        )  # dev: failed transfer
+        if len(_response) > 0:
+            assert convert(_response, bool)  # dev: failed transfer
+        # end "safeTransferFrom"
+        # Handle potential Tether fees
+        if coin == FEE_ASSET:
+            amount: uint256 = ERC20(FEE_ASSET).balanceOf(self)
+            if i < MAX_COIN:
+                meta_amounts[i] = amount
+            else:
+                base_amounts[i] = amount
+    # End transfer
+
+    # Deposit to the base pool
+    CurveBase(self.base_pool).add_liquidity(base_amounts, 0)
+    meta_amounts[MAX_COIN] = ERC20(self.coins[MAX_COIN]).balanceOf(self)
+
+    # Deposit to the meta pool
+    CurveMeta(self.pool).add_liquidity(meta_amounts, min_mint_amount)
+
+    # Transfer meta token back
+    _token: address = self.token
+    assert ERC20(_token).transfer(
+        msg.sender, ERC20(_token).balanceOf(self))
+
+
+@external
+@nonreentrant('lock')
+def remove_liquidity(_amount: uint256, min_amounts: uint256[N_ALL_COINS]):
+    _token: address = self.token
+    assert ERC20(_token).transferFrom(msg.sender, self, _amount)
+
+    # Withdraw from meta
+    min_amounts_meta: uint256[N_COINS] = empty(uint256[N_COINS])
+    for i in range(MAX_COIN):
+        min_amounts_meta[i] = min_amounts[i]
+    CurveMeta(self.pool).remove_liquidity(_amount, min_amounts_meta)
+
+    # Withdraw from base
+    _base_amount: uint256 = ERC20(_token).balanceOf(self)
+    min_amounts_base: uint256[BASE_N_COINS] = empty(uint256[BASE_N_COINS])
+    for i in range(BASE_N_COINS):
+        min_amounts_base[i] = min_amounts[MAX_COIN+i]
+    CurveBase(self.base_pool).remove_liquidity(_base_amount, min_amounts_base)
+
+    # Transfer all coins out
+    for i in range(N_ALL_COINS):
+        coin: address = ZERO_ADDRESS
+        if i < MAX_COIN:
+            coin = self.coins[i]
+        else:
+            coin = self.base_coins[i - MAX_COIN]
+        coin_amount: uint256 = ERC20(coin).balanceOf(self)
+        # "safeTransfer" which works for ERC20s which return bool or not
+        _response: Bytes[32] = raw_call(
+            coin,
+            concat(
+                method_id("transfer(address,uint256)"),
+                convert(msg.sender, bytes32),
+                convert(coin_amount, bytes32),
+            ),
+            max_outsize=32,
+        )  # dev: failed transfer
+        if len(_response) > 0:
+            assert convert(_response, bool)  # dev: failed transfer
+        # end "safeTransfer"
+    # End transfer
+
+@external
+@nonreentrant('lock')
+def remove_liquidity_one_coin(_token_amount: uint256, i: int128, min_amount: uint256):
+    _token: address = self.token
+    assert ERC20(_token).transferFrom(msg.sender, self, _token_amount)
+
+    coin: address = ZERO_ADDRESS
+    if i < MAX_COIN:
+        coin = self.coins[i]
+        # Withdraw a metapool coin
+        CurveMeta(self.pool).remove_liquidity_one_coin(_token_amount, i, min_amount)
+    else:
+        coin = self.base_coins[i - MAX_COIN]
+        # Withdraw a base pool coin
+        CurveMeta(self.pool).remove_liquidity_one_coin(_token_amount, MAX_COIN, 0)
+        CurveBase(self.base_pool).remove_liquidity_one_coin(
+            ERC20(self.coins[MAX_COIN]).balanceOf(self), i-MAX_COIN, min_amount
+        )
+
+    # Tranfer the coin out
+    coin_amount: uint256 = ERC20(coin).balanceOf(self)
+    # "safeTransfer" which works for ERC20s which return bool or not
+    _response: Bytes[32] = raw_call(
+        coin,
+        concat(
+            method_id("transfer(address,uint256)"),
+            convert(msg.sender, bytes32),
+            convert(coin_amount, bytes32),
+        ),
+        max_outsize=32,
+    )  # dev: failed transfer
+    if len(_response) > 0:
+        assert convert(_response, bool)  # dev: failed transfer
+    # end "safeTransfer"
+
+
+@view
+@external
+def calc_withdraw_one_coin(_token_amount: uint256, i: int128) -> uint256:
+    if i < MAX_COIN:
+        return CurveMeta(self.pool).calc_withdraw_one_coin(_token_amount, i)
+    else:
+        _base_tokens: uint256 = CurveMeta(self.pool).calc_withdraw_one_coin(_token_amount, MAX_COIN)
+        return CurveBase(self.base_pool).calc_withdraw_one_coin(_base_tokens, i-MAX_COIN)
+
+
+@view
+@external
+def calc_token_amount(amounts: uint256[N_ALL_COINS], deposit: bool) -> uint256:
+    meta_amounts: uint256[N_COINS] = empty(uint256[N_COINS])
+    for i in range(MAX_COIN):
+        meta_amounts[i] = amounts[i]
+    base_amounts: uint256[BASE_N_COINS] = empty(uint256[BASE_N_COINS])
+    for i in range(BASE_N_COINS):
+        base_amounts[i] = amounts[i + MAX_COIN]
+
+    _base_tokens: uint256 = CurveBase(self.base_pool).calc_token_amount(base_amounts, deposit)
+    meta_amounts[MAX_COIN] = _base_tokens
+
+    return CurveMeta(self.pool).calc_token_amount(meta_amounts, deposit)

--- a/contracts/pool-templates/meta/DepositTemplateMeta.vy
+++ b/contracts/pool-templates/meta/DepositTemplateMeta.vy
@@ -151,7 +151,7 @@ def remove_liquidity(_amount: uint256, min_amounts: uint256[N_ALL_COINS]) -> uin
     CurveMeta(self.pool).remove_liquidity(_amount, min_amounts_meta)
 
     # Withdraw from base
-    _base_amount: uint256 = ERC20(_token).balanceOf(self)
+    _base_amount: uint256 = ERC20(self.coins[1]).balanceOf(self)
     min_amounts_base: uint256[BASE_N_COINS] = empty(uint256[BASE_N_COINS])
     for i in range(BASE_N_COINS):
         min_amounts_base[i] = min_amounts[MAX_COIN+i]

--- a/contracts/pool-templates/meta/DepositTemplateMeta.vy
+++ b/contracts/pool-templates/meta/DepositTemplateMeta.vy
@@ -1,4 +1,4 @@
-# @version 0.2.4
+# @version ^0.2.0
 # (c) Curve.Fi, 2020
 # Deposit zap for the metapool
 #
@@ -148,20 +148,21 @@ def remove_liquidity(_amount: uint256, min_amounts: uint256[N_ALL_COINS]) -> uin
     _token: address = self.token
     assert ERC20(_token).transferFrom(msg.sender, self, _amount)
 
-    # Withdraw from meta
     min_amounts_meta: uint256[N_COINS] = empty(uint256[N_COINS])
+    min_amounts_base: uint256[BASE_N_COINS] = empty(uint256[BASE_N_COINS])
+    amounts: uint256[N_ALL_COINS] = empty(uint256[N_ALL_COINS])
+
+    # Withdraw from meta
     for i in range(MAX_COIN):
         min_amounts_meta[i] = min_amounts[i]
     CurveMeta(self.pool).remove_liquidity(_amount, min_amounts_meta)
 
     # Withdraw from base
     _base_amount: uint256 = ERC20(self.coins[1]).balanceOf(self)
-    min_amounts_base: uint256[BASE_N_COINS] = empty(uint256[BASE_N_COINS])
     for i in range(BASE_N_COINS):
         min_amounts_base[i] = min_amounts[MAX_COIN+i]
     CurveBase(self.base_pool).remove_liquidity(_base_amount, min_amounts_base)
 
-    amounts: uint256[N_ALL_COINS] = empty(uint256[N_ALL_COINS])
     # Transfer all coins out
     for i in range(N_ALL_COINS):
         coin: address = ZERO_ADDRESS
@@ -239,9 +240,11 @@ def calc_withdraw_one_coin(_token_amount: uint256, i: int128) -> uint256:
 @external
 def calc_token_amount(amounts: uint256[N_ALL_COINS], deposit: bool) -> uint256:
     meta_amounts: uint256[N_COINS] = empty(uint256[N_COINS])
+    base_amounts: uint256[BASE_N_COINS] = empty(uint256[BASE_N_COINS])
+
     for i in range(MAX_COIN):
         meta_amounts[i] = amounts[i]
-    base_amounts: uint256[BASE_N_COINS] = empty(uint256[BASE_N_COINS])
+
     for i in range(BASE_N_COINS):
         base_amounts[i] = amounts[i + MAX_COIN]
 

--- a/contracts/pool-templates/meta/DepositTemplateMeta.vy
+++ b/contracts/pool-templates/meta/DepositTemplateMeta.vy
@@ -53,12 +53,34 @@ def __init__(_pool: address, _token: address):
     for i in range(N_COINS):
         coin: address = CurveMeta(_pool).coins(convert(i, uint256))
         self.coins[i] = coin
-        ERC20(coin).approve(_pool, MAX_UINT256)
+        # approve coins for infinite transfers
+        _response: Bytes[32] = raw_call(
+            coin,
+            concat(
+                method_id("approve(address,uint256)"),
+                convert(_pool, bytes32),
+                convert(MAX_UINT256, bytes32),
+            ),
+            max_outsize=32,
+        )
+        if len(_response) > 0:
+            assert convert(_response, bool)
 
     for i in range(BASE_N_COINS):
         coin: address = CurveBase(_base_pool).coins(convert(i, uint256))
         self.base_coins[i] = coin
-        ERC20(coin).approve(self, MAX_UINT256)
+        # approve underlying coins for infinite transfers
+        _response: Bytes[32] = raw_call(
+            coin,
+            concat(
+                method_id("approve(address,uint256)"),
+                convert(_base_pool, bytes32),
+                convert(MAX_UINT256, bytes32),
+            ),
+            max_outsize=32,
+        )
+        if len(_response) > 0:
+            assert convert(_response, bool)
 
 
 @external

--- a/contracts/pool-templates/meta/SwapTemplateMeta.vy
+++ b/contracts/pool-templates/meta/SwapTemplateMeta.vy
@@ -184,7 +184,19 @@ def __init__(
     for i in range(BASE_POOL_COINS):
         _base_coin: address = Curve(_base_pool).coins(convert(i, uint256))
         self.base_coins[i] = _base_coin
-        ERC20(_base_coin).approve(_base_pool, MAX_UINT256)
+
+        # approve underlying coins for infinite transfers
+        _response: Bytes[32] = raw_call(
+            _base_coin,
+            concat(
+                method_id("approve(address,uint256)"),
+                convert(_base_pool, bytes32),
+                convert(MAX_UINT256, bytes32),
+            ),
+            max_outsize=32,
+        )
+        if len(_response) > 0:
+            assert convert(_response, bool)
 
 
 @view

--- a/contracts/pool-templates/meta/SwapTemplateMeta.vy
+++ b/contracts/pool-templates/meta/SwapTemplateMeta.vy
@@ -1,0 +1,993 @@
+# @version 0.2.4
+# (c) Curve.Fi, 2020
+# Metapool
+#
+# Coins 0 .. N_COINS-2 are normal coins
+# Coin N_COINS-1 is another pool token which has get_virtual_price()
+
+from vyper.interfaces import ERC20
+
+
+interface CurveToken:
+    def totalSupply() -> uint256: view
+    def mint(_to: address, _value: uint256) -> bool: nonpayable
+    def burnFrom(_to: address, _value: uint256) -> bool: nonpayable
+
+
+interface Curve:
+    def coins(i: uint256) -> address: view
+    def get_virtual_price() -> uint256: view
+    def calc_token_amount(amounts: uint256[BASE_N_COINS], deposit: bool) -> uint256: view
+    def calc_withdraw_one_coin(_token_amount: uint256, i: int128) -> uint256: view
+    def fee() -> uint256: view
+    def get_dy(i: int128, j: int128, dx: uint256) -> uint256: view
+    def get_dy_underlying(i: int128, j: int128, dx: uint256) -> uint256: view
+    def exchange(i: int128, j: int128, dx: uint256, min_dy: uint256): nonpayable
+    def add_liquidity(amounts: uint256[BASE_N_COINS], min_mint_amount: uint256): nonpayable
+    def remove_liquidity_one_coin(_token_amount: uint256, i: int128, min_amount: uint256): nonpayable
+
+
+# Events
+event TokenExchange:
+    buyer: indexed(address)
+    sold_id: int128
+    tokens_sold: uint256
+    bought_id: int128
+    tokens_bought: uint256
+
+
+event AddLiquidity:
+    provider: indexed(address)
+    token_amounts: uint256[N_COINS]
+    fees: uint256[N_COINS]
+    invariant: uint256
+    token_supply: uint256
+
+event RemoveLiquidity:
+    provider: indexed(address)
+    token_amounts: uint256[N_COINS]
+    fees: uint256[N_COINS]
+    token_supply: uint256
+
+event RemoveLiquidityOne:
+    provider: indexed(address)
+    token_amount: uint256
+    coin_amount: uint256
+
+event RemoveLiquidityImbalance:
+    provider: indexed(address)
+    token_amounts: uint256[N_COINS]
+    fees: uint256[N_COINS]
+    invariant: uint256
+    token_supply: uint256
+
+event CommitNewAdmin:
+    deadline: indexed(uint256)
+    admin: indexed(address)
+
+event NewAdmin:
+    admin: indexed(address)
+
+
+event CommitNewFee:
+    deadline: indexed(uint256)
+    fee: uint256
+    admin_fee: uint256
+
+event NewFee:
+    fee: uint256
+    admin_fee: uint256
+
+event RampA:
+    old_A: uint256
+    new_A: uint256
+    initial_time: uint256
+    future_time: uint256
+
+event StopRampA:
+    A: uint256
+    t: uint256
+
+
+# This can (and needs to) be changed at compile time
+N_COINS: constant(int128) = ___N_COINS___
+MAX_COIN: constant(int128) = N_COINS - 1
+
+FEE_DENOMINATOR: constant(uint256) = 10 ** 10
+PRECISION: constant(uint256) = 10 ** 18  # The precision to convert to
+PRECISION_MUL: constant(uint256[N_COINS]) = ___PRECISION_MUL___
+RATES: constant(uint256[N_COINS]) = ___RATES___
+
+BASE_N_COINS: constant(int128) = ___BASE_N_COINS___
+N_ALL_COINS: constant(int128) = N_COINS + BASE_N_COINS - 1
+BASE_PRECISION_MUL: constant(uint256[BASE_N_COINS]) = ___BASE_PRECISION_MUL___
+BASE_RATES: constant(uint256[BASE_N_COINS]) = ___BASE_RATES___
+
+# An asset shich may have a transfer fee (USDT)
+FEE_ASSET: constant(address) = 0xdAC17F958D2ee523a2206206994597C13D831ec7
+
+MAX_ADMIN_FEE: constant(uint256) = 10 * 10 ** 9
+MAX_FEE: constant(uint256) = 5 * 10 ** 9
+MAX_A: constant(uint256) = 10 ** 6
+MAX_A_CHANGE: constant(uint256) = 10
+
+ADMIN_ACTIONS_DELAY: constant(uint256) = 3 * 86400
+MIN_RAMP_TIME: constant(uint256) = 86400
+
+coins: public(address[N_COINS])
+balances: public(uint256[N_COINS])
+fee: public(uint256)  # fee * 1e10
+admin_fee: public(uint256)  # admin_fee * 1e10
+
+owner: public(address)
+token: CurveToken
+
+# Token corresponding to the pool is always the last one
+BASE_POOL_COINS: constant(int128) = 3
+BASE_CACHE_EXPIRES: constant(int128) = 10 * 60  # 10 min
+base_pool: public(address)
+base_virtual_price: public(uint256)
+base_cache_updated: public(uint256)
+base_coins: public(address[BASE_POOL_COINS])
+
+A_PRECISION: constant(uint256) = 100
+initial_A: public(uint256)
+future_A: public(uint256)
+initial_A_time: public(uint256)
+future_A_time: public(uint256)
+
+admin_actions_deadline: public(uint256)
+transfer_ownership_deadline: public(uint256)
+future_fee: public(uint256)
+future_admin_fee: public(uint256)
+future_owner: public(address)
+
+is_killed: bool
+kill_deadline: uint256
+KILL_DEADLINE_DT: constant(uint256) = 2 * 30 * 86400
+
+
+@external
+def __init__(
+    _owner: address,
+    _coins: address[N_COINS],
+    _pool_token: address,
+    _base_pool: address,
+    _A: uint256,
+    _fee: uint256,
+    _admin_fee: uint256
+):
+    """
+    @notice Contract constructor
+    @param _owner Contract owner address
+    @param _coins Addresses of ERC20 conracts of coins
+    @param _pool_token Address of the token representing LP share
+    @param _base_pool Address of the base pool (which will have a virtual price)
+    @param _A Amplification coefficient multiplied by n * (n - 1)
+    @param _fee Fee to charge for exchanges
+    @param _admin_fee Admin fee
+    """
+    for i in range(N_COINS):
+        assert _coins[i] != ZERO_ADDRESS
+    self.coins = _coins
+    self.initial_A = _A * A_PRECISION
+    self.future_A = _A * A_PRECISION
+    self.fee = _fee
+    self.admin_fee = _admin_fee
+    self.owner = _owner
+    self.kill_deadline = block.timestamp + KILL_DEADLINE_DT
+    self.token = CurveToken(_pool_token)
+
+    self.base_pool = _base_pool
+    self.base_virtual_price = Curve(_base_pool).get_virtual_price()
+    self.base_cache_updated = block.timestamp
+    for i in range(BASE_POOL_COINS):
+        _base_coin: address = Curve(_base_pool).coins(convert(i, uint256))
+        self.base_coins[i] = _base_coin
+        ERC20(_base_coin).approve(_base_pool, MAX_UINT256)
+
+
+@view
+@internal
+def _A() -> uint256:
+    """
+    Handle ramping A up or down
+    """
+    t1: uint256 = self.future_A_time
+    A1: uint256 = self.future_A
+
+    if block.timestamp < t1:
+        A0: uint256 = self.initial_A
+        t0: uint256 = self.initial_A_time
+        # Expressions in uint256 cannot have negative numbers, thus "if"
+        if A1 > A0:
+            return A0 + (A1 - A0) * (block.timestamp - t0) / (t1 - t0)
+        else:
+            return A0 - (A0 - A1) * (block.timestamp - t0) / (t1 - t0)
+
+    else:  # when t1 == 0 or block.timestamp >= t1
+        return A1
+
+
+@view
+@external
+def A() -> uint256:
+    return self._A() / A_PRECISION
+
+
+@view
+@external
+def A_precise() -> uint256:
+    return self._A()
+
+
+@view
+@internal
+def _xp(vp_rate: uint256) -> uint256[N_COINS]:
+    result: uint256[N_COINS] = RATES
+    result[MAX_COIN] = vp_rate  # virtual price for the metacurrency
+    for i in range(N_COINS):
+        result[i] = result[i] * self.balances[i] / PRECISION
+    return result
+
+
+@pure
+@internal
+def _xp_mem(vp_rate: uint256, _balances: uint256[N_COINS]) -> uint256[N_COINS]:
+    result: uint256[N_COINS] = RATES
+    result[MAX_COIN] = vp_rate  # virtual price for the metacurrency
+    for i in range(N_COINS):
+        result[i] = result[i] * _balances[i] / PRECISION
+    return result
+
+
+@internal
+def _vp_rate() -> uint256:
+    if block.timestamp > self.base_cache_updated + BASE_CACHE_EXPIRES:
+        vprice: uint256 = Curve(self.base_pool).get_virtual_price()
+        self.base_virtual_price = vprice
+        self.base_cache_updated = block.timestamp
+        return vprice
+    else:
+        return self.base_virtual_price
+
+
+@internal
+@view
+def _vp_rate_ro() -> uint256:
+    if block.timestamp > self.base_cache_updated + BASE_CACHE_EXPIRES:
+        return Curve(self.base_pool).get_virtual_price()
+    else:
+        return self.base_virtual_price
+
+
+@pure
+@internal
+def get_D(xp: uint256[N_COINS], amp: uint256) -> uint256:
+    S: uint256 = 0
+    for _x in xp:
+        S += _x
+    if S == 0:
+        return 0
+
+    Dprev: uint256 = 0
+    D: uint256 = S
+    Ann: uint256 = amp * N_COINS
+    for _i in range(255):
+        D_P: uint256 = D
+        for _x in xp:
+            D_P = D_P * D / (_x * N_COINS)  # If division by 0, this will be borked: only withdrawal will work. And that is good
+        Dprev = D
+        D = (Ann * S / A_PRECISION + D_P * N_COINS) * D / ((Ann - A_PRECISION) * D / A_PRECISION + (N_COINS + 1) * D_P)
+        # Equality with the precision of 1
+        if D > Dprev:
+            if D - Dprev <= 1:
+                break
+        else:
+            if Dprev - D <= 1:
+                break
+    return D
+
+
+@view
+@internal
+def get_D_mem(vp_rate: uint256, _balances: uint256[N_COINS], amp: uint256) -> uint256:
+    return self.get_D(self._xp_mem(vp_rate, _balances), amp)
+
+
+@view
+@external
+def get_virtual_price() -> uint256:
+    """
+    Returns portfolio virtual price (for calculating profit)
+    scaled up by 1e18
+    """
+    D: uint256 = self.get_D(self._xp(self._vp_rate_ro()), self._A())
+    # D is in the units similar to DAI (e.g. converted to precision 1e18)
+    # When balanced, D = n * x_u - total virtual value of the portfolio
+    token_supply: uint256 = self.token.totalSupply()
+    return D * PRECISION / token_supply
+
+
+@view
+@external
+def calc_token_amount(amounts: uint256[N_COINS], deposit: bool) -> uint256:
+    """
+    Simplified method to calculate addition or reduction in token supply at
+    deposit or withdrawal without taking fees into account (but looking at
+    slippage).
+    Needed to prevent front-running, not for precise calculations!
+    """
+    _balances: uint256[N_COINS] = self.balances
+    amp: uint256 = self._A()
+    vp_rate: uint256 = self._vp_rate_ro()
+    D0: uint256 = self.get_D_mem(vp_rate, _balances, amp)
+    for i in range(N_COINS):
+        if deposit:
+            _balances[i] += amounts[i]
+        else:
+            _balances[i] -= amounts[i]
+    D1: uint256 = self.get_D_mem(vp_rate, _balances, amp)
+    token_amount: uint256 = self.token.totalSupply()
+    diff: uint256 = 0
+    if deposit:
+        diff = D1 - D0
+    else:
+        diff = D0 - D1
+    return diff * token_amount / D0
+
+
+@external
+@nonreentrant('lock')
+def add_liquidity(amounts: uint256[N_COINS], min_mint_amount: uint256):
+    assert not self.is_killed  # dev: is killed
+
+    fees: uint256[N_COINS] = empty(uint256[N_COINS])
+    _fee: uint256 = self.fee * N_COINS / (4 * (N_COINS - 1))
+    _admin_fee: uint256 = self.admin_fee
+    amp: uint256 = self._A()
+    vp_rate: uint256 = self._vp_rate()
+
+    token_supply: uint256 = self.token.totalSupply()
+    # Initial invariant
+    D0: uint256 = 0
+    old_balances: uint256[N_COINS] = self.balances
+    if token_supply > 0:
+        D0 = self.get_D_mem(vp_rate, old_balances, amp)
+    new_balances: uint256[N_COINS] = old_balances
+
+    for i in range(N_COINS):
+        if token_supply == 0:
+            assert amounts[i] > 0  # dev: initial deposit requires all coins
+        # balances store amounts of c-tokens
+        new_balances[i] = old_balances[i] + amounts[i]
+
+    # Invariant after change
+    D1: uint256 = self.get_D_mem(vp_rate, new_balances, amp)
+    assert D1 > D0
+
+    # We need to recalculate the invariant accounting for fees
+    # to calculate fair user's share
+    D2: uint256 = D1
+    if token_supply > 0:
+        # Only account for fees if we are not the first to deposit
+        for i in range(N_COINS):
+            ideal_balance: uint256 = D1 * old_balances[i] / D0
+            difference: uint256 = 0
+            if ideal_balance > new_balances[i]:
+                difference = ideal_balance - new_balances[i]
+            else:
+                difference = new_balances[i] - ideal_balance
+            fees[i] = _fee * difference / FEE_DENOMINATOR
+            self.balances[i] = new_balances[i] - (fees[i] * _admin_fee / FEE_DENOMINATOR)
+            new_balances[i] -= fees[i]
+        D2 = self.get_D_mem(vp_rate, new_balances, amp)
+    else:
+        self.balances = new_balances
+
+    # Calculate, how much pool tokens to mint
+    mint_amount: uint256 = 0
+    if token_supply == 0:
+        mint_amount = D1  # Take the dust if there was any
+    else:
+        mint_amount = token_supply * (D2 - D0) / D0
+
+    assert mint_amount >= min_mint_amount, "Slippage screwed you"
+
+    # Take coins from the sender
+    for i in range(N_COINS):
+        if amounts[i] > 0:
+            assert ERC20(self.coins[i]).transferFrom(msg.sender, self, amounts[i])  # dev: failed transfer
+
+    # Mint pool tokens
+    self.token.mint(msg.sender, mint_amount)
+
+    log AddLiquidity(msg.sender, amounts, fees, D1, token_supply + mint_amount)
+
+
+@view
+@internal
+def get_y(i: int128, j: int128, x: uint256, xp_: uint256[N_COINS]) -> uint256:
+    # x in the input is converted to the same price/precision
+
+    assert i != j       # dev: same coin
+    assert j >= 0       # dev: j below zero
+    assert j < N_COINS  # dev: j above N_COINS
+
+    # should be unreachable, but good for safety
+    assert i >= 0
+    assert i < N_COINS
+
+    amp: uint256 = self._A()
+    D: uint256 = self.get_D(xp_, amp)
+    c: uint256 = D
+    S_: uint256 = 0
+    Ann: uint256 = amp * N_COINS
+
+    _x: uint256 = 0
+    for _i in range(N_COINS):
+        if _i == i:
+            _x = x
+        elif _i != j:
+            _x = xp_[_i]
+        else:
+            continue
+        S_ += _x
+        c = c * D / (_x * N_COINS)
+    c = c * D * A_PRECISION / (Ann * N_COINS)
+    b: uint256 = S_ + D * A_PRECISION / Ann  # - D
+    y_prev: uint256 = 0
+    y: uint256 = D
+    for _i in range(255):
+        y_prev = y
+        y = (y*y + c) / (2 * y + b - D)
+        # Equality with the precision of 1
+        if y > y_prev:
+            if y - y_prev <= 1:
+                break
+        else:
+            if y_prev - y <= 1:
+                break
+    return y
+
+
+@view
+@external
+def get_dy(i: int128, j: int128, dx: uint256) -> uint256:
+    # dx and dy in c-units
+    rates: uint256[N_COINS] = RATES
+    rates[MAX_COIN] = self._vp_rate_ro()
+    xp: uint256[N_COINS] = self._xp(rates[MAX_COIN])
+
+    x: uint256 = xp[i] + (dx * rates[i] / PRECISION)
+    y: uint256 = self.get_y(i, j, x, xp)
+    dy: uint256 = xp[j] - y - 1
+    _fee: uint256 = self.fee * dy / FEE_DENOMINATOR
+    return (dy - _fee) * PRECISION / rates[j]
+
+
+@view
+@external
+def get_dy_underlying(i: int128, j: int128, dx: uint256) -> uint256:
+    # dx and dy in underlying units
+    vp_rate: uint256 = self._vp_rate_ro()
+    xp: uint256[N_COINS] = self._xp(vp_rate)
+    precisions: uint256[N_COINS] = PRECISION_MUL
+    _base_pool: address = self.base_pool
+
+    # Use base_i or base_j if they are >= 0
+    base_i: int128 = i - MAX_COIN
+    base_j: int128 = j - MAX_COIN
+    meta_i: int128 = MAX_COIN
+    meta_j: int128 = MAX_COIN
+    if base_i < 0:
+        meta_i = i
+    if base_j < 0:
+        meta_j = j
+
+    x: uint256 = 0
+    if base_i < 0:
+        x = xp[i] + dx * precisions[i]
+    else:
+        if base_j < 0:
+            # i is from BasePool
+            # At first, get the amount of pool tokens
+            base_inputs: uint256[BASE_N_COINS] = empty(uint256[BASE_N_COINS])
+            base_inputs[base_i] = dx
+            # Token amount transformed to underlying "dollars"
+            x = Curve(_base_pool).calc_token_amount(base_inputs, True) * vp_rate / PRECISION
+            # Accounting for deposit/withdraw fees approximately
+            x -= x * Curve(_base_pool).fee() / (2 * FEE_DENOMINATOR)
+            # Adding number of pool tokens
+            x += xp[MAX_COIN]
+        else:
+            # If both are from the base pool
+            return Curve(_base_pool).get_dy(base_i, base_j, dx)
+
+    # This pool is involved only when in-pool assets are used
+    y: uint256 = self.get_y(meta_i, meta_j, x, xp)
+    dy: uint256 = xp[meta_j] - y - 1
+    dy = (dy - self.fee * dy / FEE_DENOMINATOR)
+
+    # If output is going via the metapool
+    if base_j < 0:
+        dy /= precisions[meta_j]
+    else:
+        # j is from BasePool
+        # The fee is already accounted for
+        dy = Curve(_base_pool).calc_withdraw_one_coin(dy * PRECISION / vp_rate, base_j)
+
+    return dy
+
+
+@external
+@nonreentrant('lock')
+def exchange(i: int128, j: int128, dx: uint256, min_dy: uint256):
+    assert not self.is_killed  # dev: is killed
+    rates: uint256[N_COINS] = RATES
+    rates[MAX_COIN] = self._vp_rate()
+
+    old_balances: uint256[N_COINS] = self.balances
+    xp: uint256[N_COINS] = self._xp_mem(rates[MAX_COIN], old_balances)
+
+    x: uint256 = xp[i] + dx * rates[i] / PRECISION
+    y: uint256 = self.get_y(i, j, x, xp)
+
+    dy: uint256 = xp[j] - y - 1  # -1 just in case there were some rounding errors
+    dy_fee: uint256 = dy * self.fee / FEE_DENOMINATOR
+
+    # Convert all to real units
+    dy = (dy - dy_fee) * PRECISION / rates[j]
+    assert dy >= min_dy, "Too few coins in result"
+
+    dy_admin_fee: uint256 = dy_fee * self.admin_fee / FEE_DENOMINATOR
+    dy_admin_fee = dy_admin_fee * PRECISION / rates[j]
+
+    # Change balances exactly in same way as we change actual ERC20 coin amounts
+    self.balances[i] = old_balances[i] + dx
+    # When rounding errors happen, we undercharge admin fee in favor of LP
+    self.balances[j] = old_balances[j] - dy - dy_admin_fee
+
+    assert ERC20(self.coins[i]).transferFrom(msg.sender, self, dx)
+    assert ERC20(self.coins[j]).transfer(msg.sender, dy)
+
+    log TokenExchange(msg.sender, i, dx, j, dy)
+
+
+@external
+@nonreentrant('lock')
+def exchange_underlying(i: int128, j: int128, dx: uint256, min_dy: uint256):
+    assert not self.is_killed  # dev: is killed
+    rates: uint256[N_COINS] = RATES
+    rates[MAX_COIN] = self._vp_rate()
+    _base_pool: address = self.base_pool
+
+    # Use base_i or base_j if they are >= 0
+    base_i: int128 = i - MAX_COIN
+    base_j: int128 = j - MAX_COIN
+    meta_i: int128 = MAX_COIN
+    meta_j: int128 = MAX_COIN
+    if base_i < 0:
+        meta_i = i
+    if base_j < 0:
+        meta_j = j
+    dy: uint256 = 0
+
+    # Addresses for input and output coins
+    input_coin: address = ZERO_ADDRESS
+    if base_i < 0:
+        input_coin = self.coins[i]
+    else:
+        input_coin = self.base_coins[base_i]
+    output_coin: address = ZERO_ADDRESS
+    if base_j < 0:
+        output_coin = self.coins[j]
+    else:
+        output_coin = self.base_coins[base_j]
+
+    # Handle potential Tether fees
+    dx_w_fee: uint256 = dx
+    if input_coin == FEE_ASSET:
+        dx_w_fee = ERC20(FEE_ASSET).balanceOf(self)
+    # "safeTransferFrom" which works for ERC20s which return bool or not
+    _response: Bytes[32] = raw_call(
+        input_coin,
+        concat(
+            method_id("transferFrom(address,address,uint256)"),
+            convert(msg.sender, bytes32),
+            convert(self, bytes32),
+            convert(dx, bytes32),
+        ),
+        max_outsize=32,
+    )  # dev: failed transfer
+    if len(_response) > 0:
+        assert convert(_response, bool)  # dev: failed transfer
+    # end "safeTransferFrom"
+    # Handle potential Tether fees
+    if input_coin == FEE_ASSET:
+        dx_w_fee = ERC20(FEE_ASSET).balanceOf(self) - dx_w_fee
+
+    if base_i < 0 or base_j < 0:
+        old_balances: uint256[N_COINS] = self.balances
+        xp: uint256[N_COINS] = self._xp_mem(rates[MAX_COIN], old_balances)
+
+        x: uint256 = 0
+        if base_i < 0:
+            x = xp[i] + dx_w_fee * rates[i] / PRECISION
+        else:
+            # i is from BasePool
+            # At first, get the amount of pool tokens
+            base_inputs: uint256[BASE_N_COINS] = empty(uint256[BASE_N_COINS])
+            base_inputs[base_i] = dx_w_fee
+            coin_i: address = self.coins[MAX_COIN]
+            # Deposit and measure delta
+            x = ERC20(coin_i).balanceOf(self)
+            Curve(_base_pool).add_liquidity(base_inputs, 0)
+            # Need to convert pool token to "virtual" units using rates
+            # dx is also different now
+            dx_w_fee = ERC20(coin_i).balanceOf(self) - x
+            x = dx_w_fee * rates[MAX_COIN] / PRECISION
+            # Adding number of pool tokens
+            x += xp[MAX_COIN]
+
+        y: uint256 = self.get_y(meta_i, meta_j, x, xp)
+
+        # Either a real coin or token
+        dy = xp[meta_j] - y - 1  # -1 just in case there were some rounding errors
+        dy_fee: uint256 = dy * self.fee / FEE_DENOMINATOR
+
+        # Convert all to real units
+        # Works for both pool coins and real coins
+        dy = (dy - dy_fee) * PRECISION / rates[meta_j]
+
+        dy_admin_fee: uint256 = dy_fee * self.admin_fee / FEE_DENOMINATOR
+        dy_admin_fee = dy_admin_fee * PRECISION / rates[meta_j]
+
+        # Change balances exactly in same way as we change actual ERC20 coin amounts
+        self.balances[meta_i] = old_balances[meta_i] + dx_w_fee
+        # When rounding errors happen, we undercharge admin fee in favor of LP
+        self.balances[meta_j] = old_balances[meta_j] - dy - dy_admin_fee
+
+        # Withdraw from the base pool if needed
+        if base_j >= 0:
+            out_amount: uint256 = ERC20(output_coin).balanceOf(self)
+            Curve(_base_pool).remove_liquidity_one_coin(dy, base_j, 0)
+            dy = ERC20(output_coin).balanceOf(self) - out_amount
+
+        assert dy >= min_dy, "Too few coins in result"
+
+    else:
+        # If both are from the base pool
+        dy = ERC20(output_coin).balanceOf(self)
+        Curve(_base_pool).exchange(base_i, base_j, dx_w_fee, min_dy)
+        dy = ERC20(output_coin).balanceOf(self) - dy
+
+    # "safeTransfer" which works for ERC20s which return bool or not
+    _response = raw_call(
+        output_coin,
+        concat(
+            method_id("transfer(address,uint256)"),
+            convert(msg.sender, bytes32),
+            convert(dy, bytes32),
+        ),
+        max_outsize=32,
+    )  # dev: failed transfer
+    if len(_response) > 0:
+        assert convert(_response, bool)  # dev: failed transfer
+    # end "safeTransfer"
+
+    log TokenExchange(msg.sender, i, dx, j, dy)
+
+
+@external
+@nonreentrant('lock')
+def remove_liquidity(_amount: uint256, min_amounts: uint256[N_COINS]):
+    total_supply: uint256 = self.token.totalSupply()
+    amounts: uint256[N_COINS] = empty(uint256[N_COINS])
+    fees: uint256[N_COINS] = empty(uint256[N_COINS])  # Fees are unused but we've got them historically in event
+
+    for i in range(N_COINS):
+        value: uint256 = self.balances[i] * _amount / total_supply
+        assert value >= min_amounts[i], "Too few coins in result"
+        self.balances[i] -= value
+        amounts[i] = value
+        assert ERC20(self.coins[i]).transfer(msg.sender, value)
+
+    self.token.burnFrom(msg.sender, _amount)  # dev: insufficient funds
+
+    log RemoveLiquidity(msg.sender, amounts, fees, total_supply - _amount)
+
+
+@external
+@nonreentrant('lock')
+def remove_liquidity_imbalance(amounts: uint256[N_COINS], max_burn_amount: uint256):
+    assert not self.is_killed  # dev: is killed
+
+    token_supply: uint256 = self.token.totalSupply()
+    assert token_supply != 0  # dev: zero total supply
+    _fee: uint256 = self.fee * N_COINS / (4 * (N_COINS - 1))
+    _admin_fee: uint256 = self.admin_fee
+    amp: uint256 = self._A()
+    vp_rate: uint256 = self._vp_rate()
+
+    old_balances: uint256[N_COINS] = self.balances
+    new_balances: uint256[N_COINS] = old_balances
+    D0: uint256 = self.get_D_mem(vp_rate, old_balances, amp)
+    for i in range(N_COINS):
+        new_balances[i] -= amounts[i]
+    D1: uint256 = self.get_D_mem(vp_rate, new_balances, amp)
+    fees: uint256[N_COINS] = empty(uint256[N_COINS])
+    for i in range(N_COINS):
+        ideal_balance: uint256 = D1 * old_balances[i] / D0
+        difference: uint256 = 0
+        if ideal_balance > new_balances[i]:
+            difference = ideal_balance - new_balances[i]
+        else:
+            difference = new_balances[i] - ideal_balance
+        fees[i] = _fee * difference / FEE_DENOMINATOR
+        self.balances[i] = new_balances[i] - (fees[i] * _admin_fee / FEE_DENOMINATOR)
+        new_balances[i] -= fees[i]
+    D2: uint256 = self.get_D_mem(vp_rate, new_balances, amp)
+
+    token_amount: uint256 = (D0 - D2) * token_supply / D0
+    assert token_amount != 0  # dev: zero tokens burned
+    token_amount += 1  # In case of rounding errors - make it unfavorable for the "attacker"
+    assert token_amount <= max_burn_amount, "Slippage screwed you"
+
+    self.token.burnFrom(msg.sender, token_amount)  # dev: insufficient funds
+    for i in range(N_COINS):
+        if amounts[i] != 0:
+            assert ERC20(self.coins[i]).transfer(msg.sender, amounts[i])
+
+    log RemoveLiquidityImbalance(msg.sender, amounts, fees, D1, token_supply - token_amount)
+
+
+@view
+@internal
+def get_y_D(A_: uint256, i: int128, xp: uint256[N_COINS], D: uint256) -> uint256:
+    """
+    Calculate x[i] if one reduces D from being calculated for xp to D
+
+    Done by solving quadratic equation iteratively.
+    x_1**2 + x1 * (sum' - (A*n**n - 1) * D / (A * n**n)) = D ** (n + 1) / (n ** (2 * n) * prod' * A)
+    x_1**2 + b*x_1 = c
+
+    x_1 = (x_1**2 + c) / (2*x_1 + b)
+    """
+    # x in the input is converted to the same price/precision
+
+    assert i >= 0  # dev: i below zero
+    assert i < N_COINS  # dev: i above N_COINS
+
+    c: uint256 = D
+    S_: uint256 = 0
+    Ann: uint256 = A_ * N_COINS
+
+    _x: uint256 = 0
+    for _i in range(N_COINS):
+        if _i != i:
+            _x = xp[_i]
+        else:
+            continue
+        S_ += _x
+        c = c * D / (_x * N_COINS)
+    c = c * D * A_PRECISION / (Ann * N_COINS)
+    b: uint256 = S_ + D * A_PRECISION / Ann
+    y_prev: uint256 = 0
+    y: uint256 = D
+    for _i in range(255):
+        y_prev = y
+        y = (y*y + c) / (2 * y + b - D)
+        # Equality with the precision of 1
+        if y > y_prev:
+            if y - y_prev <= 1:
+                break
+        else:
+            if y_prev - y <= 1:
+                break
+    return y
+
+
+@view
+@internal
+def _calc_withdraw_one_coin(_token_amount: uint256, i: int128, vp_rate: uint256) -> (uint256, uint256):
+    # First, need to calculate
+    # * Get current D
+    # * Solve Eqn against y_i for D - _token_amount
+    amp: uint256 = self._A()
+    _fee: uint256 = self.fee * N_COINS / (4 * (N_COINS - 1))
+    rates: uint256[N_COINS] = RATES
+    rates[MAX_COIN] = vp_rate
+    total_supply: uint256 = self.token.totalSupply()
+
+    xp: uint256[N_COINS] = self._xp(vp_rate)
+
+    D0: uint256 = self.get_D(xp, amp)
+    D1: uint256 = D0 - _token_amount * D0 / total_supply
+    xp_reduced: uint256[N_COINS] = xp
+
+    new_y: uint256 = self.get_y_D(amp, i, xp, D1)
+    dy_0: uint256 = (xp[i] - new_y) * PRECISION / rates[i]  # w/o fees
+
+    for j in range(N_COINS):
+        dx_expected: uint256 = 0
+        if j == i:
+            dx_expected = xp[j] * D1 / D0 - new_y
+        else:
+            dx_expected = xp[j] - xp[j] * D1 / D0
+        xp_reduced[j] -= _fee * dx_expected / FEE_DENOMINATOR
+
+    dy: uint256 = xp_reduced[i] - self.get_y_D(amp, i, xp_reduced, D1)
+    dy = (dy - 1) * PRECISION / rates[i]  # Withdraw less to account for rounding errors
+
+    return dy, dy_0 - dy
+
+
+@view
+@external
+def calc_withdraw_one_coin(_token_amount: uint256, i: int128) -> uint256:
+    return self._calc_withdraw_one_coin(_token_amount, i, self._vp_rate_ro())[0]
+
+
+@external
+@nonreentrant('lock')
+def remove_liquidity_one_coin(_token_amount: uint256, i: int128, min_amount: uint256):
+    """
+    Remove _amount of liquidity all in a form of coin i
+    """
+    assert not self.is_killed  # dev: is killed
+
+    dy: uint256 = 0
+    dy_fee: uint256 = 0
+    dy, dy_fee = self._calc_withdraw_one_coin(_token_amount, i, self._vp_rate())
+    assert dy >= min_amount, "Not enough coins removed"
+
+    self.balances[i] -= (dy + dy_fee * self.admin_fee / FEE_DENOMINATOR)
+    self.token.burnFrom(msg.sender, _token_amount)  # dev: insufficient funds
+    assert ERC20(self.coins[i]).transfer(msg.sender, dy)
+
+    log RemoveLiquidityOne(msg.sender, _token_amount, dy)
+
+
+### Admin functions ###
+@external
+def ramp_A(_future_A: uint256, _future_time: uint256):
+    assert msg.sender == self.owner  # dev: only owner
+    assert block.timestamp >= self.initial_A_time + MIN_RAMP_TIME
+    assert _future_time >= block.timestamp + MIN_RAMP_TIME  # dev: insufficient time
+
+    _initial_A: uint256 = self._A()
+    _future_A_p: uint256 = _future_A * A_PRECISION
+
+    assert _future_A > 0 and _future_A < MAX_A
+    if _future_A_p < _initial_A:
+        assert _future_A_p * MAX_A_CHANGE >= _initial_A
+    else:
+        assert _future_A_p <= _initial_A * MAX_A_CHANGE
+
+    self.initial_A = _initial_A
+    self.future_A = _future_A_p
+    self.initial_A_time = block.timestamp
+    self.future_A_time = _future_time
+
+    log RampA(_initial_A, _future_A_p, block.timestamp, _future_time)
+
+
+@external
+def stop_ramp_A():
+    assert msg.sender == self.owner  # dev: only owner
+
+    current_A: uint256 = self._A()
+    self.initial_A = current_A
+    self.future_A = current_A
+    self.initial_A_time = block.timestamp
+    self.future_A_time = block.timestamp
+    # now (block.timestamp < t1) is always False, so we return saved A
+
+    log StopRampA(current_A, block.timestamp)
+
+
+@external
+def commit_new_fee(new_fee: uint256, new_admin_fee: uint256):
+    assert msg.sender == self.owner  # dev: only owner
+    assert self.admin_actions_deadline == 0  # dev: active action
+    assert new_fee <= MAX_FEE  # dev: fee exceeds maximum
+    assert new_admin_fee <= MAX_ADMIN_FEE  # dev: admin fee exceeds maximum
+
+    _deadline: uint256 = block.timestamp + ADMIN_ACTIONS_DELAY
+    self.admin_actions_deadline = _deadline
+    self.future_fee = new_fee
+    self.future_admin_fee = new_admin_fee
+
+    log CommitNewFee(_deadline, new_fee, new_admin_fee)
+
+
+@external
+def apply_new_fee():
+    assert msg.sender == self.owner  # dev: only owner
+    assert block.timestamp >= self.admin_actions_deadline  # dev: insufficient time
+    assert self.admin_actions_deadline != 0  # dev: no active action
+
+    self.admin_actions_deadline = 0
+    _fee: uint256 = self.future_fee
+    _admin_fee: uint256 = self.future_admin_fee
+    self.fee = _fee
+    self.admin_fee = _admin_fee
+
+    log NewFee(_fee, _admin_fee)
+
+
+@external
+def revert_new_parameters():
+    assert msg.sender == self.owner  # dev: only owner
+
+    self.admin_actions_deadline = 0
+
+
+@external
+def commit_transfer_ownership(_owner: address):
+    assert msg.sender == self.owner  # dev: only owner
+    assert self.transfer_ownership_deadline == 0  # dev: active transfer
+
+    _deadline: uint256 = block.timestamp + ADMIN_ACTIONS_DELAY
+    self.transfer_ownership_deadline = _deadline
+    self.future_owner = _owner
+
+    log CommitNewAdmin(_deadline, _owner)
+
+
+@external
+def apply_transfer_ownership():
+    assert msg.sender == self.owner  # dev: only owner
+    assert block.timestamp >= self.transfer_ownership_deadline  # dev: insufficient time
+    assert self.transfer_ownership_deadline != 0  # dev: no active transfer
+
+    self.transfer_ownership_deadline = 0
+    _owner: address = self.future_owner
+    self.owner = _owner
+
+    log NewAdmin(_owner)
+
+
+@external
+def revert_transfer_ownership():
+    assert msg.sender == self.owner  # dev: only owner
+
+    self.transfer_ownership_deadline = 0
+
+
+@view
+@external
+def admin_balances(i: uint256) -> uint256:
+    return ERC20(self.coins[i]).balanceOf(self) - self.balances[i]
+
+
+@external
+def withdraw_admin_fees():
+    assert msg.sender == self.owner  # dev: only owner
+
+    for i in range(N_COINS):
+        c: address = self.coins[i]
+        value: uint256 = ERC20(c).balanceOf(self) - self.balances[i]
+        if value > 0:
+            assert ERC20(c).transfer(msg.sender, value)
+
+
+@external
+def donate_admin_fees():
+    assert msg.sender == self.owner  # dev: only owner
+    for i in range(N_COINS):
+        self.balances[i] = ERC20(self.coins[i]).balanceOf(self)
+
+
+@external
+def kill_me():
+    assert msg.sender == self.owner  # dev: only owner
+    assert self.kill_deadline > block.timestamp  # dev: deadline has passed
+    self.is_killed = True
+
+
+@external
+def unkill_me():
+    assert msg.sender == self.owner  # dev: only owner
+    self.is_killed = False

--- a/contracts/pool-templates/meta/pooldata.json
+++ b/contracts/pool-templates/meta/pooldata.json
@@ -1,0 +1,15 @@
+{
+    "base_pool_contract": "SwapTemplateBase",
+    "coins": [
+        {
+            "decimals": 18,
+            "tethered": false,
+            "wrapped": false
+        },
+        {
+            "decimals": 18,
+            "wrapped": false,
+            "base_pool_token": true
+        }
+    ]
+}

--- a/contracts/pools/README.md
+++ b/contracts/pools/README.md
@@ -46,3 +46,31 @@ Each subdirectory holds contracts and other files specific to a single Curve poo
     ]
 }
 ```
+
+### Metapools
+
+A metapool is a pool where a stablecoin is paired against the LP token from another pool.
+
+The `pooldata.json` for a metapool is similar to that of a regular pool:
+
+```js
+{
+    "lp_contract": "CurveContractV2",         // LP token contract to use with this pool, from `contracts/tokens`
+    "base_pool_contract": "SwapTemplateBase", // Contract name for the related base pool
+    "coins": [
+        {
+            // the first coin in the metapool is an unwrapped stablecoin
+            "decimals": 18,
+            "tethered": false,
+            "wrapped": false
+        },
+        {
+            // the second coin in the metapool is the LP token from the base pool
+            "decimals": 18,
+            "wrapped": false,
+            "base_pool_token": true
+        }
+    ]
+
+}
+```

--- a/contracts/testing/Registry.vy
+++ b/contracts/testing/Registry.vy
@@ -1,4 +1,4 @@
-# @version ^0.2.0
+# @version 0.2.4
 
 MAX_COINS: constant(int128) = 8
 CALC_INPUT_SIZE: constant(int128) = 100

--- a/tests/README.md
+++ b/tests/README.md
@@ -96,10 +96,12 @@ def test_deposits(zap):
     ...
 ```
 
-### `itercoins(*arg)`
+### `itercoins(*arg, underlying=False)`
 Parametrizes each of the given arguments with a range of numbers equal to the total number of coins for the given pool. When multiple arguments are given, each argument has a unique value for every generated test.
 
 For example, `itercoins("send", "recv")` with a pool of 3 coins will parametrize with the sequence `[(0, 1), (0, 2), (1, 0), (1, 2), (2, 0), (2, 1)]`.
+
+If `underlying` is set as `True`, the upper bound of iteration corresponds to the true number of underlying coins. This is useful when testing metapools.
 
 ```python
 @pytest.mark.itercoins("send", "recv"):

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -5,7 +5,8 @@ Pytest fixtures used in Curve's test suite.
 ## Files
 
 * [`accounts.py`](accounts.py): Convenience fixtures to aid readability when accessing specific accounts
-* [`deployments.py`](deployments.py): Contract deployment fixtures
+* [`coins.py`](coins.py): Deployment fixtures for stablecoins and LP tokens
+* [`deployments.py`](deployments.py): Deployment fixtures for pools, depositors and other contracts
 * [`functions.py`](functions.py): Functions-as-fixtures, used to standardize contract interactions or to access commonly needed functionality
 * [`pooldata.py`](pooldata.py): Pool dependent data fixtures
 * [`setup.py`](setup.py): Test setup fixtures, used for common processes such as adding initial liquidity or approving token transfers
@@ -20,6 +21,14 @@ Session scoped convenience fixtures providing access to specific unlocked accoun
 * `bob`: Yields `web3.eth.accounts[1]`.
 * `charlie`: Yields `web3.eth.accounts[2]`.
 
+### `coins.py`
+
+Module scoped deployment fixtures for stablecoins and pool LP tokens.
+
+* `pool_token`: [`CurveToken`](../../contracts/tokens) deployment for the active pool.
+* `underlying_coins`: A list of mocked token contracts representing the underlying coins in the active pool. When the pool being tested is a metapool, this list includes the underlying assets for the base pool - NOT the base pool LP token.
+* `wrapped_coins`: A list of mocked token contracts representing the wrapped coins in the active pool. The contract used is determined based on `pooldata.json` for the active pool. For pools without lending, these are the same deployments as `underlying_coins`.
+
 ### `deployments.py`
 
 Module scoped contract deployment fixtures.
@@ -27,11 +36,9 @@ Module scoped contract deployment fixtures.
 All deployment fixtures are [parametrized](https://docs.pytest.org/en/stable/parametrize.html) to work with every pool in [`contracts/pools`](../../contracts/pools). To add a new pool to the test suite, create a `pooldata.json` in the same subdirectory. You can read about the structure of this JSON file [here](../../contracts/pools/README.md).
 
 * `gauge_controller`: [`GaugeControllerMock`](../../contrcts/testing/GaugeControllerMock.vy) deployment.
-* `pool_token`: [`CurveToken`](../../contracts/tokens) deployment for the active pool.
 * `registry`: [`Registry`](../../contracts/testing/Registry.vy) deployment, with the active pool added.
 * `swap`: [`StableSwap`](../../contracts/pool-templates) deployment for the pool being tested.
-* `underlying_coins`: A list of mocked token contracts representing the underlying coins in the active pool.
-* `wrapped_coins`: A list of mocked token contracts representing the wrapped coins in the active pool. The contract used is determined based on `pooldata.json` for the active pool. For pools without lending, these are the same deployments as `underlying_coins`.
+
 * `zap`: [`Deposit`](../../contracts/pool-templates) deployment for the pool being tested.
 
 ### `functions.py`
@@ -48,7 +55,7 @@ Data fixtures for accessing information about the pool currently being tested.
 
 * `underlying_decimals`: A list of decimal values for each deployment in `underlying_coins`.
 * `wrapped_decimals`: A list of decimal values for each deployment in `wrapped_coins`.
-* `initial_amounts`: A list values equivalent to $100,000 for each deployment in `wrapped_coins`. Used for minting and providing initial liquidity.
+* `initial_amounts`: A list values equivalent to $1,000,000 for each deployment in `wrapped_coins`. Used for minting and providing initial liquidity.
 * `n_coins`: The number of coins in the active `swap` deployment.
 
 ### `setup.py`

--- a/tests/fixtures/coins.py
+++ b/tests/fixtures/coins.py
@@ -1,0 +1,155 @@
+import pytest
+import requests
+
+from brownie import Contract, ERC20Mock, ERC20MockNoReturn
+from brownie.convert import to_address
+
+from conftest import WRAPPED_COIN_METHODS
+
+_holders = {}
+
+
+# public fixtures - these can be used when testing
+
+@pytest.fixture(scope="module")
+def wrapped_coins(project, alice, pool_data, _underlying_coins, is_forked):
+    return _wrapped(project, alice, pool_data, _underlying_coins, is_forked)
+
+
+@pytest.fixture(scope="module")
+def underlying_coins(_underlying_coins, _base_coins):
+    if _base_coins:
+        return _underlying_coins[:1] + _base_coins
+    else:
+        return _underlying_coins
+
+
+@pytest.fixture(scope="module")
+def pool_token(project, alice, pool_data):
+    return _pool_token(project, alice, pool_data)
+
+
+@pytest.fixture(scope="module")
+def base_pool_token(project, charlie, base_pool_data):
+    if base_pool_data is not None:
+
+        # we do some voodoo here to make the base LP tokens work like test ERC20's
+        # charlie is the initial liquidity provider, he starts with the full balance
+        def _mint_for_testing(target, amount, tx=None):
+            token.transfer(target, amount, {'from': charlie})
+
+        token = _pool_token(project, charlie, base_pool_data)
+        token._mint_for_testing = _mint_for_testing
+        return token
+
+
+# private API below
+
+class _MintableTestToken(Contract):
+
+    def __init__(self, address, pool_data):
+        super().__init__(address)
+
+        # standardize mint / rate methods
+        if 'wrapped_contract' in pool_data:
+            fn_names = WRAPPED_COIN_METHODS[pool_data['wrapped_contract']]
+            for target, attr in fn_names.items():
+                if hasattr(self, attr):
+                    setattr(self, target, getattr(self, attr))
+
+        # get top token holder addresses
+        address = self.address
+        if address not in _holders:
+            holders = requests.get(
+                f"https://api.ethplorer.io/getTopTokenHolders/{address}",
+                params={'apiKey': "freekey", 'limit': 50},
+            ).json()
+            _holders[address] = [to_address(i['address']) for i in holders['holders']]
+
+    def _mint_for_testing(self, target, amount, tx=None):
+        for address in _holders[self.address].copy():
+            if address == self.address:
+                # don't claim from the treasury - that could cause wierdness
+                continue
+
+            balance = self.balanceOf(address)
+            if amount > balance:
+                self.transfer(target, balance, {'from': address})
+                amount -= balance
+            else:
+                self.transfer(target, amount, {'from': address})
+                return
+
+        raise ValueError("Insufficient tokens available to mint")
+
+
+def _wrapped(project, alice, pool_data, underlying_coins, is_forked):
+    coins = []
+
+    if not pool_data.get("wrapped_contract"):
+        return underlying_coins
+
+    if is_forked:
+        for i, coin_data in enumerate(pool_data['coins']):
+            if not coin_data['wrapped']:
+                coins.append(underlying_coins[i])
+            else:
+                coins.append(_MintableTestToken(coin_data['wrapped_address'], pool_data))
+        return coins
+
+    fn_names = WRAPPED_COIN_METHODS[pool_data['wrapped_contract']]
+    deployer = getattr(project, pool_data['wrapped_contract'])
+    for i, coin_data in enumerate(pool_data['coins']):
+        underlying = underlying_coins[i]
+        if not coin_data['wrapped']:
+            coins.append(underlying)
+        else:
+            decimals = coin_data['wrapped_decimals']
+            name = coin_data.get("name", f"Coin {i}")
+            symbol = coin_data.get("name", f"C{i}")
+            contract = deployer.deploy(name, symbol, decimals, underlying, {'from': alice})
+            for target, attr in fn_names.items():
+                setattr(contract, target, getattr(contract, attr))
+            if coin_data.get("withdrawal_fee"):
+                contract._set_withdrawal_fee(coin_data["withdrawal_fee"], {'from': alice})
+            coins.append(contract)
+    return coins
+
+
+def _underlying(alice, pool_data, is_forked, base_pool_token):
+    coins = []
+
+    if is_forked:
+        for data in pool_data['coins']:
+            coins.append(_MintableTestToken(data['underlying_address'], pool_data))
+    else:
+        for i, coin_data in enumerate(pool_data['coins']):
+            if coin_data.get("base_pool_token"):
+                coins.append(base_pool_token)
+                continue
+            decimals = coin_data['decimals']
+            deployer = ERC20MockNoReturn if coin_data['tethered'] else ERC20Mock
+            contract = deployer.deploy(f"Underlying Coin {i}", f"UC{i}", decimals, {'from': alice})
+            coins.append(contract)
+
+    return coins
+
+
+def _pool_token(project, alice, pool_data):
+    name = pool_data['name']
+    deployer = getattr(project, pool_data['lp_contract'])
+    return deployer.deploy(f"Curve {name} LP Token", f"{name}CRV", 18, 0, {'from': alice})
+
+
+# private fixtures used for setup in other fixtures - do not use in tests!
+
+@pytest.fixture(scope="module")
+def _underlying_coins(alice, pool_data, is_forked, base_pool_token, _add_base_pool_liquidity):
+    return _underlying(alice, pool_data, is_forked, base_pool_token)
+
+
+@pytest.fixture(scope="module")
+def _base_coins(alice, base_pool_data, is_forked):
+    if base_pool_data is None:
+        return []
+    return _underlying(alice, base_pool_data, is_forked, None)

--- a/tests/fixtures/deployments.py
+++ b/tests/fixtures/deployments.py
@@ -1,127 +1,19 @@
 import pytest
-import requests
 
-from brownie.convert import to_address
-
-from conftest import WRAPPED_COIN_METHODS
 from scripts.utils import right_pad, pack_values
 
 ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 
 
-@pytest.fixture(scope="module")
-def MintableTestToken(Contract, accounts, web3, pool_data):
-
-    class _MintableTestToken(Contract):
-
-        _holders = {}
-
-        def __init__(self, address):
-            super().__init__(address)
-
-            # standardize mint / rate methods
-            if 'wrapped_contract' in pool_data:
-                fn_names = WRAPPED_COIN_METHODS[pool_data['wrapped_contract']]
-                for target, attr in fn_names.items():
-                    if hasattr(self, attr):
-                        setattr(self, target, getattr(self, attr))
-
-            # get top token holder addresses
-            address = self.address
-            if address not in self._holders:
-                holders = requests.get(
-                    f"https://api.ethplorer.io/getTopTokenHolders/{address}",
-                    params={'apiKey': "freekey", 'limit': 50},
-                ).json()
-                self._holders[address] = [to_address(i['address']) for i in holders['holders']]
-
-        def _mint_for_testing(self, target, amount, tx=None):
-            for address in self._holders[self.address].copy():
-                if address == self.address:
-                    # don't claim from the treasury - that could cause wierdness
-                    continue
-
-                balance = self.balanceOf(address)
-                if amount > balance:
-                    self.transfer(target, balance, {'from': address})
-                    amount -= balance
-                else:
-                    self.transfer(target, amount, {'from': address})
-                    return
-
-            raise ValueError("Insufficient tokens available to mint")
-
-    yield _MintableTestToken
-
-
-@pytest.fixture(scope="module")
-def wrapped_coins(MintableTestToken, project, alice, pool_data, underlying_coins, is_forked):
-    coins = []
-
-    if not pool_data.get("wrapped_contract"):
-        yield underlying_coins
-
-    elif is_forked:
-        for i, coin_data in enumerate(pool_data['coins']):
-            if not coin_data['wrapped']:
-                coins.append(underlying_coins[i])
-            else:
-                coins.append(MintableTestToken(coin_data['wrapped_address']))
-        yield coins
-
-    else:
-        fn_names = WRAPPED_COIN_METHODS[pool_data['wrapped_contract']]
-        deployer = getattr(project, pool_data['wrapped_contract'])
-        for i, coin_data in enumerate(pool_data['coins']):
-            underlying = underlying_coins[i]
-            if not coin_data['wrapped']:
-                coins.append(underlying)
-            else:
-                decimals = coin_data['wrapped_decimals']
-                name = coin_data.get("name", f"Coin {i}")
-                symbol = coin_data.get("name", f"C{i}")
-                contract = deployer.deploy(name, symbol, decimals, underlying, {'from': alice})
-                for target, attr in fn_names.items():
-                    setattr(contract, target, getattr(contract, attr))
-                if coin_data.get("withdrawal_fee"):
-                    contract._set_withdrawal_fee(coin_data["withdrawal_fee"], {'from': alice})
-                coins.append(contract)
-        yield coins
-
-
-@pytest.fixture(scope="module")
-def underlying_coins(MintableTestToken, ERC20Mock, ERC20MockNoReturn, alice, pool_data, is_forked):
-    coins = []
-
-    if is_forked:
-        for data in pool_data['coins']:
-            coins.append(MintableTestToken(data['underlying_address']))
-    else:
-        for i, coin_data in enumerate(pool_data['coins']):
-            decimals = coin_data['decimals']
-            deployer = ERC20MockNoReturn if coin_data['tethered'] else ERC20Mock
-            contract = deployer.deploy(f"Underlying Coin {i}", f"UC{i}", decimals, {'from': alice})
-            coins.append(contract)
-
-    yield coins
-
-
-@pytest.fixture(scope="module")
-def pool_token(project, alice, pool_data):
-    name = pool_data['name']
-    deployer = getattr(project, pool_data['lp_contract'])
-    yield deployer.deploy(f"Curve {name} LP Token", f"{name}CRV", 18, 0, {'from': alice})
-
-
-@pytest.fixture(scope="module")
-def swap(project, alice, underlying_coins, wrapped_coins, pool_token, pool_data, swap_mock):
+def _swap(project, alice, underlying, wrapped, pool_token, pool_data, swap_mock, base_swap):
     deployer = getattr(project, pool_data['swap_contract'])
 
     abi = next(i['inputs'] for i in deployer.abi if i['type'] == "constructor")
     args = {
-        '_coins': wrapped_coins,
-        '_underlying_coins': underlying_coins,
+        '_coins': wrapped,
+        '_underlying_coins': underlying,
         '_pool_token': pool_token,
+        '_base_pool': base_swap,
         '_A': 360 * 2,
         '_fee': 0,
         '_admin_fee': 0,
@@ -134,16 +26,43 @@ def swap(project, alice, underlying_coins, wrapped_coins, pool_token, pool_data,
     contract = deployer.deploy(*deployment_args)
     pool_token.set_minter(contract, {'from': alice})
 
-    yield contract
+    return contract
+
+
+@pytest.fixture(scope="module")
+def swap(project, alice, _underlying_coins, wrapped_coins, pool_token, pool_data, swap_mock, base_swap):
+    return _swap(project, alice, _underlying_coins, wrapped_coins, pool_token, pool_data, swap_mock, base_swap)
+
+
+@pytest.fixture(scope="module")
+def base_swap(project, charlie, _base_coins, base_pool_token, base_pool_data):
+    if base_pool_data is not None:
+        return _swap(project, charlie, _base_coins, _base_coins, base_pool_token, base_pool_data, None, None)
+
+
+@pytest.fixture(scope="module")
+def swap_mock(SwapMock, pool_data, alice):
+    if pool_data['name'] == "snow":
+        return SwapMock.deploy({'from': alice})
 
 
 @pytest.fixture(scope="module")
 def zap(project, alice, swap, underlying_coins, wrapped_coins, pool_token, pool_data):
     deployer = getattr(project, pool_data.get('zap_contract'), None)
     if deployer is None:
-        yield False
-    else:
-        yield deployer.deploy(wrapped_coins, underlying_coins, swap, pool_token, {'from': alice})
+        return
+
+    abi = next(i['inputs'] for i in deployer.abi if i['type'] == "constructor")
+    args = {
+        '_coins': wrapped_coins,
+        '_underlying_coins': underlying_coins,
+        '_token': pool_token,
+        '_pool': swap,
+        '_curve': swap,
+    }
+    deployment_args = [args[i['name']] for i in abi] + [({'from': alice})]
+
+    return deployer.deploy(*deployment_args)
 
 
 @pytest.fixture(scope="module")
@@ -156,7 +75,6 @@ def registry(
     n_coins,
     wrapped_coins,
     wrapped_decimals,
-    underlying_decimals,
     pool_data,
 ):
     registry = Registry.deploy(gauge_controller, {'from': alice})
@@ -176,7 +94,7 @@ def registry(
             ZERO_ADDRESS,
             rate_sig,
             pack_values(wrapped_decimals),
-            pack_values(underlying_decimals),
+            pack_values([i['decimals'] for i in pool_data['coins']]),
             has_initial_A,
             is_v1,
             {'from': alice}
@@ -189,24 +107,16 @@ def registry(
             pool_token,
             ZERO_ADDRESS,
             rate_sig,
-            pack_values(underlying_decimals),
+            pack_values([i['decimals'] for i in pool_data['coins']]),
             pack_values(use_rates),
             has_initial_A,
             is_v1,
             {'from': alice}
         )
 
-    yield registry
+    return registry
 
 
 @pytest.fixture(scope="module")
 def gauge_controller(GaugeControllerMock, alice):
-    yield GaugeControllerMock.deploy({'from': alice})
-
-
-@pytest.fixture(scope="module")
-def swap_mock(SwapMock, pool_data, alice):
-    if pool_data['name'] == "snow":
-        yield SwapMock.deploy({'from': alice})
-    else:
-        yield False
+    return GaugeControllerMock.deploy({'from': alice})

--- a/tests/fixtures/pooldata.py
+++ b/tests/fixtures/pooldata.py
@@ -1,12 +1,14 @@
 import pytest
 
 
-# pool-dependent data fixtures
+# pools
 
 @pytest.fixture(scope="module")
-def underlying_decimals(pool_data):
+def underlying_decimals(pool_data, base_pool_data):
     # number of decimal places for each underlying coin in the active pool
-    yield [i['decimals'] for i in pool_data['coins']]
+    if base_pool_data is None:
+        return [i['decimals'] for i in pool_data['coins']]
+    return [pool_data['coins'][0]['decimals']] + [i['decimals'] for i in base_pool_data['coins']]
 
 
 @pytest.fixture(scope="module")
@@ -22,5 +24,21 @@ def initial_amounts(wrapped_decimals):
 
 
 @pytest.fixture(scope="module")
+def initial_amounts_underlying(underlying_decimals, is_metapool, n_coins):
+    amounts = [10**(i+6) for i in underlying_decimals]
+    if is_metapool:
+        # for a metapool, amount[0] == amount[1:] when wrapped
+        divisor = len(underlying_decimals) - 1
+        return [amounts[0]] + [i // divisor for i in amounts[1:]]
+    else:
+        return amounts
+
+
+@pytest.fixture(scope="module")
 def n_coins(pool_data):
     yield len(pool_data['coins'])
+
+
+@pytest.fixture(scope="module")
+def is_metapool(base_pool_data):
+    return bool(base_pool_data)

--- a/tests/fixtures/setup.py
+++ b/tests/fixtures/setup.py
@@ -1,67 +1,66 @@
 import pytest
 
 
+# shared logic for pool and base_pool setup fixtures
+
+def _add_liquidity(acct, swap, coins, amounts):
+    eth_value = 0
+    if "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE" in coins:
+        eth_value = 10 ** 24
+
+    swap.add_liquidity(amounts, 0, {'from': acct, 'value': eth_value})
+
+
+def _mint(acct, wrapped_coins, wrapped_amounts, underlying_coins, underlying_amounts):
+    for coin, amount in zip(wrapped_coins, wrapped_amounts):
+        if coin == "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE":
+            continue
+        coin._mint_for_testing(acct, amount, {'from': acct})
+
+    for coin, amount in zip(underlying_coins, underlying_amounts):
+        if coin == "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE" or coin in wrapped_coins:
+            continue
+        coin._mint_for_testing(acct, amount, {'from': acct})
+
+
+def _approve(owner, spender, *coins):
+    for coin in set(x for i in coins for x in i):
+        if coin == "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE":
+            continue
+        coin.approve(spender, 2**256-1, {'from': owner})
+
+
+# pool setup fixtures
+
 @pytest.fixture(scope="module")
 def add_initial_liquidity(alice, mint_alice, approve_alice, underlying_coins, swap, initial_amounts):
     # mint (10**7 * precision) of each coin in the pool
-    eth_value = 0
-    if "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE" in underlying_coins:
-        eth_value = 10 ** 24
-
-    swap.add_liquidity(initial_amounts, 0, {'from': alice, 'value': eth_value})
+    _add_liquidity(alice, swap, underlying_coins, initial_amounts)
 
 
 @pytest.fixture(scope="module")
-def mint_bob(bob, underlying_coins, wrapped_coins, initial_amounts):
-    for underlying, wrapped, amount in zip(underlying_coins, wrapped_coins, initial_amounts):
-        if underlying == "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE":
-            continue
-
-        if underlying != wrapped:
-            wrapped._mint_for_testing(bob, amount, {'from': bob})
-            amount = amount * 10 ** wrapped.decimals() / 10 ** underlying.decimals()
-            underlying._mint_for_testing(bob, amount, {'from': bob})
-        else:
-            underlying._mint_for_testing(bob, amount, {'from': bob})
+def mint_bob(bob, underlying_coins, wrapped_coins, initial_amounts, initial_amounts_underlying):
+    _mint(bob, wrapped_coins, initial_amounts, underlying_coins, initial_amounts_underlying)
 
 
 @pytest.fixture(scope="module")
-def approve_bob(bob, underlying_coins, wrapped_coins, swap, initial_amounts):
-    for underlying, wrapped, amount in zip(underlying_coins, wrapped_coins, initial_amounts):
-        if underlying == "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE":
-            continue
-        underlying.approve(swap, 2**256-1, {'from': bob})
-        if underlying != wrapped:
-            wrapped.approve(swap, 2**256-1, {'from': bob})
+def approve_bob(bob, swap, underlying_coins, wrapped_coins):
+    _approve(bob, swap, underlying_coins, wrapped_coins)
 
 
 @pytest.fixture(scope="module")
-def mint_alice(alice, underlying_coins, wrapped_coins, initial_amounts):
-    for underlying, wrapped, amount in zip(underlying_coins, wrapped_coins, initial_amounts):
-        if underlying == "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE":
-            continue
-
-        if underlying != wrapped:
-            wrapped._mint_for_testing(alice, amount, {'from': alice})
-            amount = amount * 10 ** wrapped.decimals() / 10 ** underlying.decimals()
-            underlying._mint_for_testing(alice, amount, {'from': alice})
-        else:
-            underlying._mint_for_testing(alice, amount, {'from': alice})
+def mint_alice(alice, underlying_coins, wrapped_coins, initial_amounts, initial_amounts_underlying):
+    _mint(alice, wrapped_coins, initial_amounts, underlying_coins, initial_amounts_underlying)
 
 
 @pytest.fixture(scope="module")
-def approve_alice(alice, underlying_coins, wrapped_coins, swap, initial_amounts):
-    for underlying, wrapped, amount in zip(underlying_coins, wrapped_coins, initial_amounts):
-        if underlying == "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE":
-            continue
-        underlying.approve(swap, 2**256-1, {'from': alice})
-        if underlying != wrapped:
-            wrapped.approve(swap, 2**256-1, {'from': alice})
+def approve_alice(alice, swap, underlying_coins, wrapped_coins):
+    _approve(alice, swap, underlying_coins, wrapped_coins)
 
 
 @pytest.fixture(scope="module")
-def approve_zap(alice, bob, zap, pool_token, underlying_coins, initial_amounts):
-    for underlying, amount in zip(underlying_coins, initial_amounts):
+def approve_zap(alice, bob, zap, pool_token, underlying_coins, initial_amounts_underlying):
+    for underlying, amount in zip(underlying_coins, initial_amounts_underlying):
         if underlying == "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE":
             continue
         underlying.approve(zap, 2**256-1, {'from': alice})
@@ -69,3 +68,16 @@ def approve_zap(alice, bob, zap, pool_token, underlying_coins, initial_amounts):
 
     pool_token.approve(zap, 2**256-1, {'from': alice})
     pool_token.approve(zap, 2**256-1, {'from': bob})
+
+
+@pytest.fixture(scope="module")
+def _add_base_pool_liquidity(charlie, base_swap, _base_coins, base_pool_data):
+    # private fixture to add liquidity to the metapool
+    if base_pool_data is None:
+        return
+
+    decimals = [i['decimals'] for i in base_pool_data['coins']]
+    initial_amounts = [2 * 10**(i+6) for i in decimals]
+    _mint(charlie, _base_coins, initial_amounts, [], [])
+    _approve(charlie, base_swap, _base_coins)
+    _add_liquidity(charlie, base_swap, _base_coins, initial_amounts)

--- a/tests/pools/common/integration/test_curve.py
+++ b/tests/pools/common/integration/test_curve.py
@@ -1,8 +1,12 @@
+import pytest
+
 from brownie.test import given, strategy
 from collections import deque
 from hypothesis import settings
 from itertools import permutations
 from simulation import Curve
+
+pytestmark = pytest.mark.skip_pool("template-meta")
 
 
 @given(

--- a/tests/pools/common/integration/test_registry.py
+++ b/tests/pools/common/integration/test_registry.py
@@ -7,7 +7,10 @@ import pytest
 
 ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 
-pytestmark = pytest.mark.usefixtures("add_initial_liquidity")
+pytestmark = [
+    pytest.mark.usefixtures("add_initial_liquidity"),
+    pytest.mark.skip_pool("template-meta")
+]
 
 
 @pytest.mark.itercoins("send", "recv")
@@ -20,10 +23,10 @@ def test_amount_dy(registry, swap, send, recv):
 
 @pytest.mark.lending
 @pytest.mark.itercoins("send", "recv")
-def test_amount_dy_underlying(registry, swap, send, recv):
+def test_amount_dy_underlying(registry, swap, send, recv, underlying_coins):
     dy = swap.get_dy_underlying(send, recv, 10**18)
-    send_address = swap.underlying_coins(send)
-    recv_address = swap.underlying_coins(recv)
+    send_address = underlying_coins[send]
+    recv_address = underlying_coins[recv]
     assert registry.get_exchange_amount(swap, send_address, recv_address, 10**18) == dy
 
 

--- a/tests/pools/common/integration/test_simulate_exchange.py
+++ b/tests/pools/common/integration/test_simulate_exchange.py
@@ -4,7 +4,10 @@ from hypothesis import settings
 from simulation import Curve
 
 # do not run this test on pools without lending
-pytestmark = pytest.mark.lending
+pytestmark = [
+    pytest.mark.lending,
+    pytest.mark.skip_pool("template-meta")
+]
 
 
 @given(

--- a/tests/pools/common/unitary/test_exchange_underlying_reverts.py
+++ b/tests/pools/common/unitary/test_exchange_underlying_reverts.py
@@ -4,18 +4,18 @@ import pytest
 pytestmark = [pytest.mark.usefixtures("add_initial_liquidity", "approve_bob"), pytest.mark.lending]
 
 
-@pytest.mark.itercoins("sending", "receiving")
+@pytest.mark.itercoins("sending", "receiving", underlying=True)
 def test_min_dy_too_high(bob, swap, underlying_coins, underlying_decimals, sending, receiving):
     amount = 10**underlying_decimals[sending]
 
     underlying_coins[sending]._mint_for_testing(bob, amount, {'from': bob})
 
-    min_dy = swap.get_dy(sending, receiving, amount)
-    with brownie.reverts("Exchange resulted in fewer coins than expected"):
+    min_dy = swap.get_dy_underlying(sending, receiving, amount)
+    with brownie.reverts():
         swap.exchange_underlying(sending, receiving, amount, min_dy+2, {'from': bob})
 
 
-@pytest.mark.itercoins("sending", "receiving")
+@pytest.mark.itercoins("sending", "receiving", underlying=True)
 def test_insufficient_balance(bob, swap, underlying_coins, underlying_decimals, sending, receiving):
     amount = 10**underlying_decimals[sending]
 
@@ -24,7 +24,7 @@ def test_insufficient_balance(bob, swap, underlying_coins, underlying_decimals, 
         swap.exchange_underlying(sending, receiving, amount+1, 0, {'from': bob})
 
 
-@pytest.mark.itercoins("idx")
+@pytest.mark.itercoins("idx", underlying=True)
 def test_same_coin(bob, swap, idx):
     with brownie.reverts():
         swap.exchange_underlying(idx, idx, 0, 0, {'from': bob})

--- a/tests/pools/common/unitary/test_ramp_A.py
+++ b/tests/pools/common/unitary/test_ramp_A.py
@@ -1,9 +1,8 @@
 import brownie
 import pytest
 
-pytestmark = pytest.mark.skip_pool(
-    "busd", "compound", "snow", "susd", "usdt", "y", "template-base", "template-y"
-)
+pytestmark = pytest.mark.target_pool("3pool", "hbtc", "pax", "sbtc")
+
 
 MIN_RAMP_TIME = 86400
 

--- a/tests/pools/common/unitary/test_ramp_A_precise.py
+++ b/tests/pools/common/unitary/test_ramp_A_precise.py
@@ -1,7 +1,9 @@
 import brownie
 import pytest
 
-pytestmark = pytest.mark.target_pool("snow", "template-base", "template-y")
+pytestmark = pytest.mark.skip_pool(
+    "3pool", "busd", "compound", "hbtc", "pax", "ren", "sbtc", "susd", "usdt", "y"
+)
 
 MIN_RAMP_TIME = 86400
 

--- a/tests/test_gas.py
+++ b/tests/test_gas.py
@@ -42,19 +42,21 @@ def test_swap_gas(
 
 
 @pytest.mark.zap
-def test_zap_gas(chain, alice, n_coins, underlying_decimals, initial_amounts, zap, approve_zap):
+def test_zap_gas(chain, alice, underlying_decimals, initial_amounts_underlying, zap, approve_zap):
     if not zap:
         return
 
-    zap.add_liquidity(initial_amounts, 0, {'from': alice})
+    n_coins = len(initial_amounts_underlying)
+    zap.add_liquidity(initial_amounts_underlying, 0, {'from': alice})
     chain.sleep(3600)
 
     zap.remove_liquidity(10**18, [0] * n_coins, {'from': alice})
     chain.sleep(3600)
 
-    amounts = [10**underlying_decimals[i] for i in range(n_coins)]
-    zap.remove_liquidity_imbalance(amounts, 2**256-1, {'from': alice})
-    chain.sleep(3600)
+    if hasattr(zap, "remove_liquidity_imbalance"):
+        amounts = [10**underlying_decimals[i] for i in range(n_coins)]
+        zap.remove_liquidity_imbalance(amounts, 2**256-1, {'from': alice})
+        chain.sleep(3600)
 
     if hasattr(zap, "remove_liquidity_one_coin"):
         for idx in range(n_coins):

--- a/tests/zaps/common/test_add_liquidity_initial_zap.py
+++ b/tests/zaps/common/test_add_liquidity_initial_zap.py
@@ -1,45 +1,36 @@
 import brownie
 import pytest
 
-pytestmark = pytest.mark.usefixtures("mint_alice", "approve_zap")
+pytestmark = pytest.mark.usefixtures("mint_bob", "approve_zap")
 
 
-@pytest.mark.parametrize("min_amount", (False, True))
-def test_initial(
-    alice,
-    zap,
-    swap,
-    underlying_coins,
-    wrapped_coins,
-    pool_token,
-    underlying_decimals,
-    n_coins,
-    initial_amounts,
-    min_amount,
-):
-    amounts = [10**i for i in underlying_decimals]
-    min_amount = 10**18 * n_coins if min_amount else 0
+def test_lp_token_balances(bob, zap, swap, pool_token, base_pool_token, initial_amounts_underlying, n_coins):
+    zap.add_liquidity(initial_amounts_underlying, 0, {'from': bob})
 
-    zap.add_liquidity(amounts, min_amount, {'from': alice})
+    assert 0.9999 < pool_token.balanceOf(bob) / (n_coins * 10**24) <= 1
+    assert pool_token.totalSupply() == pool_token.balanceOf(bob)
 
-    zipped = zip(underlying_coins, wrapped_coins, amounts, initial_amounts)
-    for underlying, wrapped, amount, initial in zipped:
-        assert underlying.balanceOf(alice) == initial - amount
 
-        if wrapped == underlying:
-            assert underlying.balanceOf(zap) == 0
-            assert underlying.balanceOf(swap) == amount
+def test_underlying_balances(bob, zap, swap, underlying_coins, wrapped_coins, initial_amounts_underlying):
+    zap.add_liquidity(initial_amounts_underlying, 0, {'from': bob})
+
+    for coin, amount in zip(underlying_coins, initial_amounts_underlying):
+        assert coin.balanceOf(zap) == 0
+        if coin in wrapped_coins:
+            assert coin.balanceOf(swap) == amount
         else:
-            assert underlying.balanceOf(zap) == 0
-            assert underlying.balanceOf(swap) == 0
-            assert wrapped.balanceOf(alice) == initial
-            assert wrapped.balanceOf(zap) == 0
-            assert wrapped.balanceOf(swap) == amount
-
-    assert pool_token.balanceOf(alice) == n_coins * 10**18
-    assert pool_token.totalSupply() == n_coins * 10**18
+            assert coin.balanceOf(swap) == 0
 
 
+def test_wrapped_balances(bob, zap, swap, wrapped_coins, initial_amounts_underlying, initial_amounts):
+    zap.add_liquidity(initial_amounts_underlying, 0, {'from': bob})
+
+    for coin, amount in zip(wrapped_coins, initial_amounts):
+        assert coin.balanceOf(zap) == 0
+        assert 0.9999 < coin.balanceOf(swap) / amount <= 1
+
+
+@pytest.mark.skip_pool("template-meta")
 @pytest.mark.itercoins("idx")
 def test_initial_liquidity_missing_coin(alice, zap, pool_token, idx, underlying_decimals):
     amounts = [10**i for i in underlying_decimals]

--- a/tests/zaps/common/test_add_liquidity_zap.py
+++ b/tests/zaps/common/test_add_liquidity_zap.py
@@ -4,61 +4,59 @@ import pytest
 pytestmark = pytest.mark.usefixtures("add_initial_liquidity", "mint_bob", "approve_zap")
 
 
-def test_add_liquidity(bob, zap, swap, underlying_coins, wrapped_coins, pool_token, initial_amounts, n_coins):
-    zap.add_liquidity(initial_amounts, 0, {'from': bob})
+def test_lp_token_balances(bob, zap, swap, pool_token, base_pool_token, initial_amounts_underlying, n_coins):
+    initial_supply = pool_token.totalSupply()
+    zap.add_liquidity(initial_amounts_underlying, 0, {'from': bob})
 
-    for wrapped, underlying, amount in zip(wrapped_coins, underlying_coins, initial_amounts):
-        assert underlying.balanceOf(bob) == 0
+    assert 0.9999 < pool_token.balanceOf(bob) / (n_coins * 10**24) <= 1
+    assert 0.9999 < (pool_token.totalSupply() / 2) / initial_supply <= 1
 
-        if wrapped == underlying:
-            assert underlying.balanceOf(zap) == 0
-            assert underlying.balanceOf(swap) == amount * 2
+
+def test_underlying_balances(bob, zap, swap, underlying_coins, wrapped_coins, initial_amounts_underlying):
+    zap.add_liquidity(initial_amounts_underlying, 0, {'from': bob})
+
+    for coin, amount in zip(underlying_coins, initial_amounts_underlying):
+        assert coin.balanceOf(zap) == 0
+        if coin in wrapped_coins:
+            assert coin.balanceOf(swap) == amount * 2
         else:
-            assert underlying.balanceOf(zap) == 0
-            assert underlying.balanceOf(swap) == 0
-            assert wrapped.balanceOf(bob) == amount
-            assert wrapped.balanceOf(zap) == 0
-            assert wrapped.balanceOf(swap) == amount * 2
-
-    assert pool_token.balanceOf(bob) == n_coins * 10**24
-    assert pool_token.totalSupply() == n_coins * 10**24 * 2
+            assert coin.balanceOf(swap) == 0
 
 
-def test_add_liquidity_with_slippage(bob, zap, pool_token, underlying_coins, underlying_decimals, n_coins):
-    amounts = [10**i for i in underlying_decimals]
-    amounts[0] = int(amounts[0] * 0.99)
-    amounts[1] = int(amounts[1] * 1.01)
+def test_wrapped_balances(bob, zap, swap, wrapped_coins, initial_amounts_underlying, initial_amounts):
+    zap.add_liquidity(initial_amounts_underlying, 0, {'from': bob})
+
+    for coin, amount in zip(wrapped_coins, initial_amounts):
+        assert coin.balanceOf(zap) == 0
+        assert 0.9999 < coin.balanceOf(swap) / (amount * 2) <= 1
+
+
+@pytest.mark.itercoins("idx")
+@pytest.mark.parametrize("mod", [0.95, 1.05])
+def test_slippage(bob, zap, pool_token, underlying_coins, wrapped_coins, initial_amounts_underlying, idx, mod):
+    amounts = [i // 10**6 for i in initial_amounts_underlying]
+    amounts[idx] = int(amounts[idx] * mod)
+
     zap.add_liquidity(amounts, 0, {'from': bob})
 
-    for coin in underlying_coins:
+    for coin in underlying_coins+wrapped_coins:
         assert coin.balanceOf(zap) == 0
 
-    assert 0.999 < pool_token.balanceOf(bob) / (n_coins * 10**18) < 1
     assert pool_token.balanceOf(zap) == 0
 
 
 @pytest.mark.itercoins("idx")
-def test_add_one_coin(bob, swap, zap, underlying_coins, wrapped_coins, pool_token, initial_amounts, idx, n_coins):
-    amounts = [0] * n_coins
-    amounts[idx] = initial_amounts[idx]
+def test_add_one_coin(bob, swap, zap, underlying_coins, wrapped_coins, underlying_decimals, pool_token, idx):
+
+    amounts = [0] * len(underlying_decimals)
+    amounts[idx] = 10 ** underlying_decimals[idx]
     zap.add_liquidity(amounts, 0, {'from': bob})
 
-    zipped = zip(underlying_coins, wrapped_coins, amounts, initial_amounts)
-    for underlying, wrapped, amount, initial in zipped:
-        assert underlying.balanceOf(bob) == initial - amount
+    for coin in underlying_coins+wrapped_coins:
+        assert coin.balanceOf(zap) == 0
 
-        if wrapped == underlying:
-            assert underlying.balanceOf(zap) == 0
-            assert underlying.balanceOf(swap) == amount + initial
-        else:
-            assert underlying.balanceOf(zap) == 0
-            assert underlying.balanceOf(swap) == 0
-            assert wrapped.balanceOf(bob) == initial
-            assert wrapped.balanceOf(zap) == 0
-            assert wrapped.balanceOf(swap) == amount + initial
-
-    assert 0.999 < pool_token.balanceOf(bob) / 10**24 < 1
     assert pool_token.balanceOf(zap) == 0
+    assert 0.999 < pool_token.balanceOf(bob) / 10**18 < 1
 
 
 def test_insufficient_balance(charlie, zap, underlying_decimals):
@@ -68,16 +66,15 @@ def test_insufficient_balance(charlie, zap, underlying_decimals):
 
 
 @pytest.mark.parametrize("min_amount", [False, True])
-def test_min_amount_too_high(alice, zap, underlying_decimals, min_amount, n_coins):
-
-    amounts = [10**i for i in underlying_decimals]
+def test_min_amount_too_high(alice, zap, initial_amounts_underlying, min_amount, n_coins):
+    amounts = [i // 10**6 for i in initial_amounts_underlying]
     min_amount = n_coins * 10**18 + 1 if min_amount else 2**256 - 1
     with brownie.reverts():
         zap.add_liquidity(amounts, min_amount, {'from': alice})
 
 
-def test_min_amount_with_slippage(bob, zap, underlying_decimals, n_coins):
-    amounts = [10**i for i in underlying_decimals]
+def test_min_amount_with_slippage(bob, zap, initial_amounts_underlying, n_coins):
+    amounts = [i // 10**6 for i in initial_amounts_underlying]
     amounts[0] = int(amounts[0] * 0.99)
     amounts[1] = int(amounts[1] * 1.01)
     with brownie.reverts():

--- a/tests/zaps/common/test_remove_liquidity_imbalance_zap.py
+++ b/tests/zaps/common/test_remove_liquidity_imbalance_zap.py
@@ -1,6 +1,9 @@
 import pytest
 
-pytestmark = pytest.mark.usefixtures("add_initial_liquidity", "approve_zap")
+pytestmark = [
+    pytest.mark.usefixtures("add_initial_liquidity", "approve_zap"),
+    pytest.mark.skip_pool("template-meta"),
+]
 
 
 @pytest.mark.itercoins("idx")

--- a/tests/zaps/common/test_return_values.py
+++ b/tests/zaps/common/test_return_values.py
@@ -6,15 +6,17 @@ pytestmark = [
 ]
 
 
-def test_remove_liquidity(alice, bob, zap, initial_amounts, pool_token, n_coins, underlying_coins):
+def test_remove_liquidity(alice, bob, zap, pool_token, underlying_coins):
+    n_coins = len(underlying_coins)
     pool_token.transfer(bob, pool_token.balanceOf(alice), {'from': alice})
     tx = zap.remove_liquidity(n_coins * 10**24 // 3, [0] * n_coins, {'from': bob})
     for coin, expected_amount in zip(underlying_coins, tx.return_value):
         assert coin.balanceOf(bob) == expected_amount
 
 
-def test_remove_imbalance(alice, bob, zap, initial_amounts, pool_token, underlying_coins):
-    amounts = [i//2 for i in initial_amounts]
+@pytest.mark.skip_pool("template-meta")
+def test_remove_imbalance(alice, bob, zap, initial_amounts_underlying, pool_token, underlying_coins):
+    amounts = [i//2 for i in initial_amounts_underlying]
     amounts[0] = 0
 
     pool_token.transfer(bob, pool_token.balanceOf(alice), {'from': alice})
@@ -30,6 +32,6 @@ def test_remove_one(alice, bob, zap, underlying_coins, wrapped_coins, pool_token
     assert tx.return_value == underlying_coins[1].balanceOf(bob)
 
 
-def test_add_liquidity(bob, zap, initial_amounts, pool_token, mint_bob):
-    tx = zap.add_liquidity(initial_amounts, 0, {'from': bob})
+def test_add_liquidity(bob, zap, initial_amounts_underlying, pool_token, mint_bob):
+    tx = zap.add_liquidity(initial_amounts_underlying, 0, {'from': bob})
     assert pool_token.balanceOf(bob) == tx.return_value


### PR DESCRIPTION
### What I did
Integrate the metapool template ([`curve-contract/pool_meta`](https://github.com/curvefi/curve-contract/tree/pool_meta)) into the master branch.

### How I did it
* The template lives at `contracts/pool-templates/template-meta`
* There are several new fields in `pooldata.json` to set up a metapool - this is all documented in the appropriate readmes
* Test fixtures have been expanded to play nicely with metapools

### Pending work
For now I've marked some of the integration tests to skip the metapool.  The python simulation of the curve needs some adjustments (cc @michwill), and the registry tests are failing (cc myself, this is my next priority).

### How to verify it
Run the tests!