### PR TITLE
Adjust test cases for ren/sbtc (pools with wrapped, no underlying)

### DIFF
--- a/contracts/pools/3pool/pooldata.json
+++ b/contracts/pools/3pool/pooldata.json
@@ -7,14 +7,12 @@
             "name": "DAI",
             "decimals": 18,
             "tethered": false,
-            "wrapped": false,
             "underlying_address": "0x6b175474e89094c44da98b954eedeac495271d0f"
         },
         {
             "name": "USDC",
             "decimals": 6,
             "tethered": false,
-            "wrapped": false,
             "underlying_address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
 
         },
@@ -22,7 +20,6 @@
             "name": "USDT",
             "decimals": 6,
             "tethered": true,
-            "wrapped": false,
             "underlying_address": "0xdac17f958d2ee523a2206206994597c13d831ec7"
         }
     ]

--- a/contracts/pools/busd/pooldata.json
+++ b/contracts/pools/busd/pooldata.json
@@ -9,7 +9,6 @@
             "name": "DAI",
             "decimals": 18,
             "tethered": false,
-            "wrapped": true,
             "wrapped_decimals": 18,
             "underlying_address": "0x6b175474e89094c44da98b954eedeac495271d0f",
             "wrapped_address": "0xc2cb1040220768554cf699b0d863a3cd4324ce32"
@@ -18,7 +17,6 @@
             "name": "USDC",
             "decimals": 6,
             "tethered": false,
-            "wrapped": true,
             "wrapped_decimals": 6,
             "underlying_address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
             "wrapped_address": "0x26ea744e5b887e5205727f55dfbe8685e3b21951"
@@ -27,7 +25,6 @@
             "name": "USDT",
             "decimals": 6,
             "tethered": true,
-            "wrapped": true,
             "wrapped_decimals": 6,
             "underlying_address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
             "wrapped_address": "0xe6354ed5bc4b393a5aad09f21c46e101e692d447"
@@ -36,7 +33,6 @@
             "name": "BUSD",
             "decimals": 18,
             "tethered": false,
-            "wrapped": true,
             "wrapped_decimals": 18,
             "underlying_address": "0x4fabb145d64652a948d72533023f6e7a623c7c53",
             "wrapped_address": "0x04bc0ab673d88ae9dbc9da2380cb6b79c4bca9ae"

--- a/contracts/pools/compound/pooldata.json
+++ b/contracts/pools/compound/pooldata.json
@@ -8,7 +8,6 @@
         {
             "decimals": 18,
             "tethered": false,
-            "wrapped": true,
             "wrapped_decimals": 18,
             "underlying_address": "0x6b175474e89094c44da98b954eedeac495271d0f",
             "wrapped_address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643"
@@ -16,7 +15,6 @@
         {
             "decimals": 6,
             "tethered": false,
-            "wrapped": true,
             "wrapped_decimals": 6,
             "underlying_address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
             "wrapped_address": "0x39aa39c021dfbae8fac545936693ac917d5e7563"

--- a/contracts/pools/gusd/pooldata.json
+++ b/contracts/pools/gusd/pooldata.json
@@ -18,13 +18,11 @@
             "name": "GUSD",
             "decimals": 2,
             "tethered": false,
-            "wrapped": false,
             "underlying_address": "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd"
         },
         {
             "name": "3CRV",
             "decimals": 18,
-            "wrapped": false,
             "base_pool_token": true,
             "underlying_address": "0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490"
         }

--- a/contracts/pools/hbtc/pooldata.json
+++ b/contracts/pools/hbtc/pooldata.json
@@ -7,14 +7,12 @@
             "name": "hBTC",
             "decimals": 18,
             "tethered": false,
-            "wrapped": false,
             "underlying_address": "0x0316EB71485b0Ab14103307bf65a021042c6d380"
         },
         {
             "name": "wBTC",
             "decimals": 8,
             "tethered": false,
-            "wrapped": false,
             "underlying_address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599"
         }
     ]

--- a/contracts/pools/husd/pooldata.json
+++ b/contracts/pools/husd/pooldata.json
@@ -18,13 +18,11 @@
             "name": "HUSD",
             "decimals": 8,
             "tethered": false,
-            "wrapped": false,
             "underlying_address": "0xdf574c24545e5ffecb9a659c229253d4111d87e1"
         },
         {
             "name": "3CRV",
             "decimals": 18,
-            "wrapped": false,
             "base_pool_token": true,
             "underlying_address": "0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490"
         }

--- a/contracts/pools/linkusd/pooldata.json
+++ b/contracts/pools/linkusd/pooldata.json
@@ -18,13 +18,11 @@
             "name": "LINKUSD",
             "decimals": 18,
             "tethered": false,
-            "wrapped": false,
             "underlying_address": "0x0E2EC54fC0B509F445631Bf4b91AB8168230C752"
         },
         {
             "name": "3CRV",
             "decimals": 18,
-            "wrapped": false,
             "base_pool_token": true,
             "underlying_address": "0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490"
         }

--- a/contracts/pools/musd/pooldata.json
+++ b/contracts/pools/musd/pooldata.json
@@ -18,13 +18,11 @@
             "name": "MUSD",
             "decimals": 18,
             "tethered": false,
-            "wrapped": false,
             "underlying_address": "0xe2f2a5C287993345a840Db3B0845fbC70f5935a5"
         },
         {
             "name": "3CRV",
             "decimals": 18,
-            "wrapped": false,
             "base_pool_token": true,
             "underlying_address": "0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490"
         }

--- a/contracts/pools/pax/pooldata.json
+++ b/contracts/pools/pax/pooldata.json
@@ -8,7 +8,6 @@
         {
             "decimals": 18,
             "tethered": false,
-            "wrapped": true,
             "wrapped_decimals": 18,
             "underlying_address": "0x6b175474e89094c44da98b954eedeac495271d0f",
             "wrapped_address": "0x99d1fa417f94dcd62bfe781a1213c092a47041bc"
@@ -16,7 +15,6 @@
         {
             "decimals": 6,
             "tethered": false,
-            "wrapped": true,
             "wrapped_decimals": 6,
             "underlying_address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
             "wrapped_address": "0x9777d7e2b60bb01759d0e2f8be2095df444cb07e"
@@ -24,7 +22,6 @@
         {
             "decimals": 6,
             "tethered": true,
-            "wrapped": true,
             "wrapped_decimals": 6,
             "underlying_address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
             "wrapped_address": "0x1be5d71f2da660bfdee8012ddc58d024448a0a59"
@@ -32,7 +29,6 @@
         {
             "decimals": 18,
             "tethered": false,
-            "wrapped": false,
             "underlying_address": "0x8e870d67f660d95d5be530380d0ec0bd388289e1"
         }
     ]

--- a/contracts/pools/ren/pooldata.json
+++ b/contracts/pools/ren/pooldata.json
@@ -5,9 +5,7 @@
     "lp_token_address": "0x49849C98ae39Fff122806C06791Fa73784FB3675",
     "coins": [
         {
-            "decimals": 8,
             "tethered": false,
-            "wrapped": true,
             "wrapped_decimals": 8,
             "underlying_address": "0xeb4c2781e4eba804ce9a9803c67d0893436bb27d",
             "wrapped_address": "0xeb4c2781e4eba804ce9a9803c67d0893436bb27d"
@@ -15,7 +13,6 @@
         {
             "decimals": 8,
             "tethered": false,
-            "wrapped": false,
             "underlying_address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599"
         }
     ]

--- a/contracts/pools/rsv/pooldata.json
+++ b/contracts/pools/rsv/pooldata.json
@@ -15,13 +15,11 @@
             "name": "RSV",
             "decimals": 18,
             "tethered": false,
-            "wrapped": false,
             "underlying_address": "0x196f4727526eA7FB1e17b2071B3d8eAA38486988"
         },
         {
             "name": "3CRV",
             "decimals": 18,
-            "wrapped": false,
             "base_pool_token": true,
             "underlying_address": "0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490"
         }

--- a/contracts/pools/sbtc/pooldata.json
+++ b/contracts/pools/sbtc/pooldata.json
@@ -5,9 +5,7 @@
     "lp_token_address": "0x075b1bb99792c9E1041bA13afEf80C91a1e70fB3",
     "coins": [
         {
-            "decimals": 8,
             "tethered": false,
-            "wrapped": true,
             "wrapped_decimals": 8,
             "underlying_address": "0xeb4c2781e4eba804ce9a9803c67d0893436bb27d",
             "wrapped_address": "0xeb4c2781e4eba804ce9a9803c67d0893436bb27d"
@@ -15,13 +13,11 @@
         {
             "decimals": 8,
             "tethered": false,
-            "wrapped": false,
             "underlying_address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599"
         },
         {
             "decimals": 18,
             "tethered": false,
-            "wrapped": false,
             "underlying_address": "0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6"
         }
     ]

--- a/contracts/pools/snow/pooldata.json
+++ b/contracts/pools/snow/pooldata.json
@@ -6,7 +6,6 @@
             "name": "DAI",
             "decimals": 18,
             "tethered": false,
-            "wrapped": true,
             "wrapped_decimals": 18,
             "withdrawal_fee": 500,
             "underlying_address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16,7 +15,6 @@
             "name": "USDC",
             "decimals": 6,
             "tethered": false,
-            "wrapped": true,
             "wrapped_decimals": 6,
             "withdrawal_fee": 500,
             "underlying_address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26,7 +24,6 @@
             "name": "USDT",
             "decimals": 6,
             "tethered": true,
-            "wrapped": true,
             "wrapped_decimals": 6,
             "withdrawal_fee": 500,
             "underlying_address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -36,7 +33,6 @@
             "name": "TUSD",
             "decimals": 18,
             "tethered": false,
-            "wrapped": true,
             "wrapped_decimals": 18,
             "withdrawal_fee": 500,
             "underlying_address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -46,7 +42,6 @@
             "name": "yCRV",
             "decimals": 18,
             "tethered": false,
-            "wrapped": true,
             "wrapped_decimals": 18,
             "withdrawal_fee": 500,
             "underlying_address": "0xdF5e0e81Dff6FAF3A7e52BA697820c5e32D806A8",
@@ -56,7 +51,6 @@
             "name": "USDC",
             "decimals": 6,
             "tethered": false,
-            "wrapped": false,
             "underlying_address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
         }
     ]

--- a/contracts/pools/susd/pooldata.json
+++ b/contracts/pools/susd/pooldata.json
@@ -8,28 +8,24 @@
             "name": "DAI",
             "decimals": 18,
             "tethered": false,
-            "wrapped": false,
             "underlying_address": "0x6b175474e89094c44da98b954eedeac495271d0f"
         },
         {
             "name": "USDC",
             "decimals": 6,
             "tethered": false,
-            "wrapped": false,
             "underlying_address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
         },
         {
             "name": "USDT",
             "decimals": 6,
             "tethered": true,
-            "wrapped": false,
             "underlying_address": "0xdac17f958d2ee523a2206206994597c13d831ec7"
         },
         {
             "name": "SUSD",
             "decimals": 18,
             "tethered": false,
-            "wrapped": false,
             "underlying_address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51"
         }
     ]

--- a/contracts/pools/usdk/pooldata.json
+++ b/contracts/pools/usdk/pooldata.json
@@ -18,13 +18,11 @@
             "name": "USDK",
             "decimals": 18,
             "tethered": false,
-            "wrapped": false,
             "underlying_address": "0x1c48f86ae57291f7686349f12601910bd8d470bb"
         },
         {
             "name": "3CRV",
             "decimals": 18,
-            "wrapped": false,
             "base_pool_token": true,
             "underlying_address": "0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490"
         }

--- a/contracts/pools/usdn/pooldata.json
+++ b/contracts/pools/usdn/pooldata.json
@@ -18,13 +18,11 @@
             "name": "USDN",
             "decimals": 18,
             "tethered": false,
-            "wrapped": false,
             "underlying_address": "0x674C6Ad92Fd080e4004b2312b45f796a192D27a0"
         },
         {
             "name": "3CRV",
             "decimals": 18,
-            "wrapped": false,
             "base_pool_token": true,
             "underlying_address": "0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490"
         }

--- a/contracts/pools/usdt/pooldata.json
+++ b/contracts/pools/usdt/pooldata.json
@@ -9,7 +9,6 @@
             "name": "DAI",
             "decimals": 18,
             "tethered": false,
-            "wrapped": true,
             "wrapped_decimals": 18,
             "underlying_address": "0x6b175474e89094c44da98b954eedeac495271d0f",
             "wrapped_address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643"
@@ -18,7 +17,6 @@
             "name": "USDC",
             "decimals": 6,
             "tethered": false,
-            "wrapped": true,
             "wrapped_decimals": 6,
             "underlying_address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
             "wrapped_address": "0x39aa39c021dfbae8fac545936693ac917d5e7563"
@@ -27,7 +25,6 @@
             "name": "USDT",
             "decimals": 6,
             "tethered": true,
-            "wrapped": false,
             "underlying_address": "0xdac17f958d2ee523a2206206994597c13d831ec7"
         }
     ]

--- a/contracts/pools/y/pooldata.json
+++ b/contracts/pools/y/pooldata.json
@@ -9,7 +9,6 @@
             "name": "DAI",
             "decimals": 18,
             "tethered": false,
-            "wrapped": true,
             "wrapped_decimals": 18,
             "underlying_address": "0x6b175474e89094c44da98b954eedeac495271d0f",
             "wrapped_address": "0x16de59092dAE5CcF4A1E6439D611fd0653f0Bd01"
@@ -18,7 +17,6 @@
             "name": "USDC",
             "decimals": 6,
             "tethered": false,
-            "wrapped": true,
             "wrapped_decimals": 6,
             "underlying_address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
             "wrapped_address": "0xd6aD7a6750A7593E092a9B218d66C0A814a3436e"
@@ -27,7 +25,6 @@
             "name": "USDT",
             "decimals": 6,
             "tethered": true,
-            "wrapped": true,
             "wrapped_decimals": 6,
             "underlying_address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
             "wrapped_address": "0x83f798e925BcD4017Eb265844FDDAbb448f1707D"
@@ -36,7 +33,6 @@
             "name": "TUSD",
             "decimals": 18,
             "tethered": false,
-            "wrapped": true,
             "wrapped_decimals": 18,
             "underlying_address": "0x0000000000085d4780b73119b644ae5ecd22b376",
             "wrapped_address": "0x73a052500105205d34daf004eab301916da8190f"

--- a/contracts/testing/renERC20.vy
+++ b/contracts/testing/renERC20.vy
@@ -174,9 +174,6 @@ def exchangeRateCurrent() -> uint256:
 
 @external
 def _mint_for_testing(_target: address, _value: uint256) -> bool:
-    _udecimals: uint256 = ERC20Mock(self.underlying_token).decimals()
-    _underlying_value: uint256 = 2 * _value * 10 ** _udecimals / 10 ** self.decimals
-    ERC20Mock(self.underlying_token)._mint_for_testing(self, _underlying_value)
     self.total_supply += _value
     self.balanceOf[_target] += _value
     log Transfer(ZERO_ADDRESS, _target, _value)

--- a/contracts/testing/renERC20.vy
+++ b/contracts/testing/renERC20.vy
@@ -29,7 +29,6 @@ balanceOf: public(HashMap[address, uint256])
 allowances: HashMap[address, HashMap[address, uint256]]
 total_supply: uint256
 
-underlying_token: address
 exchangeRateStored: public(uint256)
 supplyRatePerBlock: public(uint256)
 accrualBlockNumber: public(uint256)
@@ -39,12 +38,11 @@ def __init__(
     _name: String[64],
     _symbol: String[32],
     _decimals: uint256,
-    _underlying_token: address,
+    _underlying_token: address,  # included for compatibility with the test suite, doesn't do anything!
 ):
     self.name = _name
     self.symbol = _symbol
     self.decimals = _decimals
-    self.underlying_token = _underlying_token
     self.exchangeRateStored = 10 ** 18
     self.accrualBlockNumber = block.number
 
@@ -83,82 +81,6 @@ def approve(_spender : address, _value : uint256) -> bool:
     self.allowances[msg.sender][_spender] = _value
     log Approval(msg.sender, _spender, _value)
     return True
-
-
-# cERC20-specific functions
-@external
-def mint(mintAmount: uint256) -> uint256:
-    """
-     @notice Sender supplies assets into the market and receives cTokens in exchange
-     @dev Accrues interest whether or not the operation succeeds, unless reverted
-     @param mintAmount The amount of the underlying asset to supply
-     @return uint 0=success, otherwise a failure
-    """
-    _response: Bytes[32] = raw_call(
-        self.underlying_token,
-        concat(
-            method_id("transferFrom(address,address,uint256)"),
-            convert(msg.sender, bytes32),
-            convert(self, bytes32),
-            convert(mintAmount, bytes32),
-        ),
-        max_outsize=32,
-    )
-    value: uint256 = mintAmount * 10 ** 18 / self.exchangeRateStored
-    self.total_supply += value
-    self.balanceOf[msg.sender] += value
-    return 0
-
-
-@external
-def redeem(redeemTokens: uint256) -> uint256:
-    """
-     @notice Sender redeems cTokens in exchange for the underlying asset
-     @dev Accrues interest whether or not the operation succeeds, unless reverted
-     @param redeemTokens The number of cTokens to redeem into underlying
-     @return uint 0=success, otherwise a failure
-    """
-    _value: uint256 = redeemTokens * self.exchangeRateStored / 10 ** 18
-    self.balanceOf[msg.sender] -= redeemTokens
-    self.total_supply -= redeemTokens
-    _response: Bytes[32] = raw_call(
-        self.underlying_token,
-        concat(
-            method_id("transfer(address,uint256)"),
-            convert(msg.sender, bytes32),
-            convert(_value, bytes32),
-        ),
-        max_outsize=32,
-    )
-    if len(_response) != 0:
-        assert convert(_response, bool)
-
-    return 0
-
-
-@external
-def redeemUnderlying(redeemAmount: uint256) -> uint256:
-    """
-     @notice Sender redeems cTokens in exchange for a specified amount of underlying asset
-     @dev Accrues interest whether or not the operation succeeds, unless reverted
-     @param redeemAmount The amount of underlying to redeem
-     @return uint 0=success, otherwise a failure
-    """
-    _value: uint256 = redeemAmount * 10 ** 18 / self.exchangeRateStored
-    self.balanceOf[msg.sender] -= _value
-    self.total_supply -= _value
-    _response: Bytes[32] = raw_call(
-        self.underlying_token,
-        concat(
-            method_id("transfer(address,uint256)"),
-            convert(msg.sender, bytes32),
-            convert(_value, bytes32),
-        ),
-        max_outsize=32,
-    )
-    if len(_response) != 0:
-        assert convert(_response, bool)
-    return 0
 
 
 @external

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,6 @@ WRAPPED_COIN_METHODS = {
     },
     "renERC20": {
         "get_rate": "exchangeRateCurrent",
-        "mint": "mint",
     },
     "yERC20": {
         "get_rate": "getPricePerFullShare",

--- a/tests/fixtures/deployments.py
+++ b/tests/fixtures/deployments.py
@@ -77,6 +77,7 @@ def registry(
     swap,
     pool_token,
     n_coins,
+    underlying_decimals,
     wrapped_coins,
     wrapped_decimals,
     pool_data,
@@ -98,20 +99,20 @@ def registry(
             ZERO_ADDRESS,
             rate_sig,
             pack_values(wrapped_decimals),
-            pack_values([i['decimals'] for i in pool_data['coins']]),
+            pack_values(underlying_decimals),
             has_initial_A,
             is_v1,
             {'from': alice}
         )
     else:
-        use_rates = [i['wrapped'] for i in pool_data['coins']] + [False] * (8 - n_coins)
+        use_rates = ['wrapped_decimals' in i for i in pool_data['coins']] + [False] * (8 - n_coins)
         registry.add_pool_without_underlying(
             swap,
             n_coins,
             pool_token,
             ZERO_ADDRESS,
             rate_sig,
-            pack_values([i['decimals'] for i in pool_data['coins']]),
+            pack_values(underlying_decimals),
             pack_values(use_rates),
             has_initial_A,
             is_v1,

--- a/tests/fixtures/pooldata.py
+++ b/tests/fixtures/pooldata.py
@@ -7,14 +7,14 @@ import pytest
 def underlying_decimals(pool_data, base_pool_data):
     # number of decimal places for each underlying coin in the active pool
     if base_pool_data is None:
-        return [i['decimals'] for i in pool_data['coins']]
+        return [i.get('decimals', i.get('wrapped_decimals')) for i in pool_data['coins']]
     return [pool_data['coins'][0]['decimals']] + [i['decimals'] for i in base_pool_data['coins']]
 
 
 @pytest.fixture(scope="module")
 def wrapped_decimals(pool_data):
     # number of decimal places for each wrapped coin in the active pool
-    yield [i.get('wrapped_decimals', i['decimals']) for i in pool_data['coins']]
+    yield [i.get('wrapped_decimals', i.get('decimals')) for i in pool_data['coins']]
 
 
 @pytest.fixture(scope="module")

--- a/tests/pools/common/integration/test_curve.py
+++ b/tests/pools/common/integration/test_curve.py
@@ -29,6 +29,7 @@ def test_curve_in_contract(
         if hasattr(wrapped, 'set_exchange_rate'):
             rate = int(10**18 * (1 + 0.1 * len(initial_liquidity)))
             wrapped.set_exchange_rate(rate, {'from': alice})
+        if hasattr(wrapped, 'mint'):
             underlying.approve(wrapped, amount, {'from': alice})
             wrapped.mint(amount, {'from': alice})
             amount = amount * 10 ** 18 // rate

--- a/tests/pools/common/integration/test_curve.py
+++ b/tests/pools/common/integration/test_curve.py
@@ -15,19 +15,18 @@ pytestmark = pytest.mark.skip_meta
 )
 @settings(max_examples=5)
 def test_curve_in_contract(
-    alice, swap, underlying_coins, wrapped_coins, st_seed_amount, pool_data, n_coins, approx, st_pct
+    alice, swap, underlying_coins, wrapped_coins, st_seed_amount, n_coins, approx, st_pct, underlying_decimals
 ):
-    coin_data = pool_data['coins']
     st_seed_amount = int(10 ** st_seed_amount)
 
     # add initial pool liquidity
     # we add at an imbalance of +10% for each subsequent coin
     initial_liquidity = []
-    for underlying, wrapped, data in zip(underlying_coins, wrapped_coins, coin_data):
-        amount = st_seed_amount * 10 ** (data['decimals'] + 1)
+    for underlying, wrapped, decimals in zip(underlying_coins, wrapped_coins, underlying_decimals):
+        amount = st_seed_amount * 10 ** decimals + 1
         underlying._mint_for_testing(alice, amount, {'from': alice})
 
-        if data['wrapped']:
+        if hasattr(wrapped, 'set_exchange_rate'):
             rate = int(10**18 * (1 + 0.1 * len(initial_liquidity)))
             wrapped.set_exchange_rate(rate, {'from': alice})
             underlying.approve(wrapped, amount, {'from': alice})
@@ -43,19 +42,19 @@ def test_curve_in_contract(
     # initialize our python model using the same parameters as the contract
     balances = [swap.balances(i) for i in range(n_coins)]
     rates = []
-    for (coin, data) in zip(wrapped_coins, pool_data['coins']):
-        if data['wrapped']:
+    for coin, decimals in zip(wrapped_coins, underlying_decimals):
+        if hasattr(coin, 'get_rate'):
             rate = coin.get_rate()
         else:
             rate = 10 ** 18
 
-        precision = 10 ** (18-data['decimals'])
+        precision = 10 ** (18-decimals)
         rates.append(rate * precision)
     curve_model = Curve(2 * 360, balances, n_coins, rates)
 
     # execute a series of swaps and compare the python model to the contract results
     rates = [
-        wrapped_coins[i].get_rate() if coin_data[i]['wrapped']
+        wrapped_coins[i].get_rate() if hasattr(wrapped_coins[i], "get_rate")
         else 10 ** 18 for i in range(n_coins)
     ]
     exchange_pairs = deque(permutations(range(n_coins), 2))
@@ -63,7 +62,7 @@ def test_curve_in_contract(
     while st_pct:
         exchange_pairs.rotate()
         send, recv = exchange_pairs[0]
-        dx = int(2 * st_seed_amount * 10 ** coin_data[send]['decimals'] * st_pct.pop())
+        dx = int(2 * st_seed_amount * 10 ** underlying_decimals[send] * st_pct.pop())
 
         dx_c = dx * 10 ** 18 // rates[send]
 
@@ -76,8 +75,8 @@ def test_curve_in_contract(
 
         dy_1 = dy_1_c * rates[recv] // 10 ** 18
 
-        dy_2 = curve_model.dy(send, recv, dx * (10 ** (18 - coin_data[send]['decimals'])))
-        dy_2 //= (10 ** (18 - coin_data[recv]['decimals']))
+        dy_2 = curve_model.dy(send, recv, dx * (10 ** (18 - underlying_decimals[send])))
+        dy_2 //= (10 ** (18 - underlying_decimals[recv]))
 
         assert approx(dy_1, dy_2, 1e-8) or abs(dy_1 - dy_2) <= 2
         assert approx(dy_1_u, dy_2, 1e-8) or abs(dy_1 - dy_2) <= 2

--- a/tests/pools/common/integration/test_simulate_exchange.py
+++ b/tests/pools/common/integration/test_simulate_exchange.py
@@ -46,7 +46,7 @@ def test_simulated_exchange(
         amount = 1000 * 10 ** data['decimals']
         underlying._mint_for_testing(alice, amount, {'from': alice})
 
-        if data['wrapped']:
+        if data.get("wrapped_decimals"):
 
             underlying.approve(wrapped, amount, {'from': alice})
             wrapped.mint(amount, {'from': alice})
@@ -62,7 +62,7 @@ def test_simulated_exchange(
     balances = [swap.balances(i) for i in range(n_coins)]
     rates = []
     for (coin, data) in zip(wrapped_coins, pool_data['coins']):
-        if data['wrapped']:
+        if data.get("wrapped_decimals"):
             rate = coin.get_rate()
         else:
             rate = 10 ** 18
@@ -82,7 +82,7 @@ def test_simulated_exchange(
     while st_coin:
         # Tune exchange rates
         for i, (cc, data) in enumerate(zip(wrapped_coins, coin_data)):
-            if data['wrapped']:
+            if data.get("wrapped_decimals"):
                 rate = int(cc.get_rate() * 1.0001)
                 cc.set_exchange_rate(rate, {'from': alice})
                 curve_model.p[i] = rate * (10 ** (18-data['decimals']))


### PR DESCRIPTION
### What I did
Fix an issue in the test suite where pools with lending-only coins were incorrectly having two different coins added.

This is a requirement for testing the tbtc pool.

### How I did it
* removed the `"wrapped"` field in `pooldata.json` - this is now implied based on the presence of `"wrapped_decimals"`
* for a pool without an underlying token, omit the `"decimals"` field
* simplify the `RenERC20` mock to not include any lending functionality

I've updated all the JSON files and modified the fixtures as needed.

### How to verify it
Confirm that tests are passing in the CI.