### PR TITLE
Improved test filtering logic

### DIFF
--- a/.github/workflows/3pool.yaml
+++ b/.github/workflows/3pool.yaml
@@ -19,8 +19,14 @@ env:
 
 jobs:
 
-  unitary-pool:
+  test:
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [pools, zaps]
+        type: [unitary, integration]
 
     steps:
     - uses: actions/checkout@v2
@@ -50,37 +56,4 @@ jobs:
         pip install -r requirements.txt
 
     - name: Run Tests
-      run: brownie test tests/pools/common/unitary --pool ${{ env.pool }}
-
-  integration:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache Compiler Installations
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.solcx
-          ~/.vvm
-        key: compiler-cache
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-
-    - name: Install Ganache
-      run: npm install
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install Requirements
-      run: |
-        pip install wheel
-        pip install -r requirements.txt
-
-    - name: Run Tests
-      run: pytest tests/pools/common/integration --pool ${{ env.pool }}
+      run: brownie test tests/${{ matrix.target }} --pool ${{ env.pool }} --${{ matrix.type }}

--- a/.github/workflows/busd.yaml
+++ b/.github/workflows/busd.yaml
@@ -19,8 +19,14 @@ env:
 
 jobs:
 
-  unitary-pool:
+  test:
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [pools, zaps]
+        type: [unitary, integration]
 
     steps:
     - uses: actions/checkout@v2
@@ -50,70 +56,4 @@ jobs:
         pip install -r requirements.txt
 
     - name: Run Tests
-      run: brownie test tests/pools/common/unitary --pool ${{ env.pool }}
-
-  integration:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache Compiler Installations
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.solcx
-          ~/.vvm
-        key: compiler-cache
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-
-    - name: Install Ganache
-      run: npm install
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install Requirements
-      run: |
-        pip install wheel
-        pip install -r requirements.txt
-
-    - name: Run Tests
-      run: pytest tests/pools/common/integration --pool ${{ env.pool }}
-
-  unitary-zap:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache Compiler Installations
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.solcx
-          ~/.vvm
-        key: compiler-cache
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-
-    - name: Install Ganache
-      run: npm install
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install Requirements
-      run: |
-        pip install wheel
-        pip install -r requirements.txt
-
-    - name: Run Tests
-      run: brownie test tests/zaps/common --pool ${{ env.pool }}
+      run: brownie test tests/${{ matrix.target }} --pool ${{ env.pool }} --${{ matrix.type }}

--- a/.github/workflows/compound.yaml
+++ b/.github/workflows/compound.yaml
@@ -19,8 +19,14 @@ env:
 
 jobs:
 
-  unitary-pool:
+  test:
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [pools, zaps]
+        type: [unitary, integration]
 
     steps:
     - uses: actions/checkout@v2
@@ -50,70 +56,4 @@ jobs:
         pip install -r requirements.txt
 
     - name: Run Tests
-      run: brownie test tests/pools/common/unitary --pool ${{ env.pool }}
-
-  integration:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache Compiler Installations
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.solcx
-          ~/.vvm
-        key: compiler-cache
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-
-    - name: Install Ganache
-      run: npm install
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install Requirements
-      run: |
-        pip install wheel
-        pip install -r requirements.txt
-
-    - name: Run Tests
-      run: pytest tests/pools/common/integration --pool ${{ env.pool }}
-
-  unitary-zap:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache Compiler Installations
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.solcx
-          ~/.vvm
-        key: compiler-cache
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-
-    - name: Install Ganache
-      run: npm install
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install Requirements
-      run: |
-        pip install wheel
-        pip install -r requirements.txt
-
-    - name: Run Tests
-      run: brownie test tests/zaps/common --pool ${{ env.pool }}
+      run: brownie test tests/${{ matrix.target }} --pool ${{ env.pool }} --${{ matrix.type }}

--- a/.github/workflows/gusd.yaml
+++ b/.github/workflows/gusd.yaml
@@ -19,8 +19,14 @@ env:
 
 jobs:
 
-  unitary-pool:
+  test:
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [pools, zaps]
+        type: [unitary, integration]
 
     steps:
     - uses: actions/checkout@v2
@@ -50,70 +56,4 @@ jobs:
         pip install -r requirements.txt
 
     - name: Run Tests
-      run: brownie test tests/pools/common/unitary --pool ${{ env.pool }}
-
-  integration:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache Compiler Installations
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.solcx
-          ~/.vvm
-        key: compiler-cache
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-
-    - name: Install Ganache
-      run: npm install
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install Requirements
-      run: |
-        pip install wheel
-        pip install -r requirements.txt
-
-    - name: Run Tests
-      run: pytest tests/pools/common/integration --pool ${{ env.pool }}
-
-  unitary-zap:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache Compiler Installations
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.solcx
-          ~/.vvm
-        key: compiler-cache
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-
-    - name: Install Ganache
-      run: npm install
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install Requirements
-      run: |
-        pip install wheel
-        pip install -r requirements.txt
-
-    - name: Run Tests
-      run: brownie test tests/zaps/common --pool ${{ env.pool }}
+      run: brownie test tests/${{ matrix.target }} --pool ${{ env.pool }} --${{ matrix.type }}

--- a/.github/workflows/hbtc.yaml
+++ b/.github/workflows/hbtc.yaml
@@ -19,8 +19,14 @@ env:
 
 jobs:
 
-  unitary-pool:
+  test:
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [pools, zaps]
+        type: [unitary, integration]
 
     steps:
     - uses: actions/checkout@v2
@@ -50,37 +56,4 @@ jobs:
         pip install -r requirements.txt
 
     - name: Run Tests
-      run: brownie test tests/pools/common/unitary --pool ${{ env.pool }}
-
-  integration:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache Compiler Installations
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.solcx
-          ~/.vvm
-        key: compiler-cache
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-
-    - name: Install Ganache
-      run: npm install
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install Requirements
-      run: |
-        pip install wheel
-        pip install -r requirements.txt
-
-    - name: Run Tests
-      run: pytest tests/pools/common/integration --pool ${{ env.pool }}
+      run: brownie test tests/${{ matrix.target }} --pool ${{ env.pool }} --${{ matrix.type }}

--- a/.github/workflows/husd.yaml
+++ b/.github/workflows/husd.yaml
@@ -19,8 +19,14 @@ env:
 
 jobs:
 
-  unitary-pool:
+  test:
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [pools, zaps]
+        type: [unitary, integration]
 
     steps:
     - uses: actions/checkout@v2
@@ -50,70 +56,4 @@ jobs:
         pip install -r requirements.txt
 
     - name: Run Tests
-      run: brownie test tests/pools/common/unitary --pool ${{ env.pool }}
-
-  integration:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache Compiler Installations
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.solcx
-          ~/.vvm
-        key: compiler-cache
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-
-    - name: Install Ganache
-      run: npm install
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install Requirements
-      run: |
-        pip install wheel
-        pip install -r requirements.txt
-
-    - name: Run Tests
-      run: pytest tests/pools/common/integration --pool ${{ env.pool }}
-
-  unitary-zap:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache Compiler Installations
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.solcx
-          ~/.vvm
-        key: compiler-cache
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-
-    - name: Install Ganache
-      run: npm install
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install Requirements
-      run: |
-        pip install wheel
-        pip install -r requirements.txt
-
-    - name: Run Tests
-      run: brownie test tests/zaps/common --pool ${{ env.pool }}
+      run: brownie test tests/${{ matrix.target }} --pool ${{ env.pool }} --${{ matrix.type }}

--- a/.github/workflows/linkusd.yaml
+++ b/.github/workflows/linkusd.yaml
@@ -19,8 +19,14 @@ env:
 
 jobs:
 
-  unitary-pool:
+  test:
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [pools, zaps]
+        type: [unitary, integration]
 
     steps:
     - uses: actions/checkout@v2
@@ -50,70 +56,4 @@ jobs:
         pip install -r requirements.txt
 
     - name: Run Tests
-      run: brownie test tests/pools/common/unitary --pool ${{ env.pool }}
-
-  integration:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache Compiler Installations
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.solcx
-          ~/.vvm
-        key: compiler-cache
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-
-    - name: Install Ganache
-      run: npm install
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install Requirements
-      run: |
-        pip install wheel
-        pip install -r requirements.txt
-
-    - name: Run Tests
-      run: pytest tests/pools/common/integration --pool ${{ env.pool }}
-
-  unitary-zap:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache Compiler Installations
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.solcx
-          ~/.vvm
-        key: compiler-cache
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-
-    - name: Install Ganache
-      run: npm install
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install Requirements
-      run: |
-        pip install wheel
-        pip install -r requirements.txt
-
-    - name: Run Tests
-      run: brownie test tests/zaps/common --pool ${{ env.pool }}
+      run: brownie test tests/${{ matrix.target }} --pool ${{ env.pool }} --${{ matrix.type }}

--- a/.github/workflows/musd.yaml
+++ b/.github/workflows/musd.yaml
@@ -19,8 +19,14 @@ env:
 
 jobs:
 
-  unitary-pool:
+  test:
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [pools, zaps]
+        type: [unitary, integration]
 
     steps:
     - uses: actions/checkout@v2
@@ -50,70 +56,4 @@ jobs:
         pip install -r requirements.txt
 
     - name: Run Tests
-      run: brownie test tests/pools/common/unitary --pool ${{ env.pool }}
-
-  integration:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache Compiler Installations
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.solcx
-          ~/.vvm
-        key: compiler-cache
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-
-    - name: Install Ganache
-      run: npm install
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install Requirements
-      run: |
-        pip install wheel
-        pip install -r requirements.txt
-
-    - name: Run Tests
-      run: pytest tests/pools/common/integration --pool ${{ env.pool }}
-
-  unitary-zap:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache Compiler Installations
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.solcx
-          ~/.vvm
-        key: compiler-cache
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-
-    - name: Install Ganache
-      run: npm install
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install Requirements
-      run: |
-        pip install wheel
-        pip install -r requirements.txt
-
-    - name: Run Tests
-      run: brownie test tests/zaps/common --pool ${{ env.pool }}
+      run: brownie test tests/${{ matrix.target }} --pool ${{ env.pool }} --${{ matrix.type }}

--- a/.github/workflows/pax.yaml
+++ b/.github/workflows/pax.yaml
@@ -19,8 +19,14 @@ env:
 
 jobs:
 
-  unitary-pool:
+  test:
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [pools, zaps]
+        type: [unitary, integration]
 
     steps:
     - uses: actions/checkout@v2
@@ -50,70 +56,4 @@ jobs:
         pip install -r requirements.txt
 
     - name: Run Tests
-      run: brownie test tests/pools/common/unitary --pool ${{ env.pool }}
-
-  integration:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache Compiler Installations
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.solcx
-          ~/.vvm
-        key: compiler-cache
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-
-    - name: Install Ganache
-      run: npm install
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install Requirements
-      run: |
-        pip install wheel
-        pip install -r requirements.txt
-
-    - name: Run Tests
-      run: pytest tests/pools/common/integration --pool ${{ env.pool }}
-
-  unitary-zap:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache Compiler Installations
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.solcx
-          ~/.vvm
-        key: compiler-cache
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-
-    - name: Install Ganache
-      run: npm install
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install Requirements
-      run: |
-        pip install wheel
-        pip install -r requirements.txt
-
-    - name: Run Tests
-      run: brownie test tests/zaps/common --pool ${{ env.pool }}
+      run: brownie test tests/${{ matrix.target }} --pool ${{ env.pool }} --${{ matrix.type }}

--- a/.github/workflows/ren.yaml
+++ b/.github/workflows/ren.yaml
@@ -19,8 +19,14 @@ env:
 
 jobs:
 
-  unitary-pool:
+  test:
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [pools, zaps]
+        type: [unitary, integration]
 
     steps:
     - uses: actions/checkout@v2
@@ -50,37 +56,4 @@ jobs:
         pip install -r requirements.txt
 
     - name: Run Tests
-      run: brownie test tests/pools/common/unitary --pool ${{ env.pool }}
-
-  integration:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache Compiler Installations
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.solcx
-          ~/.vvm
-        key: compiler-cache
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-
-    - name: Install Ganache
-      run: npm install
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install Requirements
-      run: |
-        pip install wheel
-        pip install -r requirements.txt
-
-    - name: Run Tests
-      run: pytest tests/pools/common/integration --pool ${{ env.pool }}
+      run: brownie test tests/${{ matrix.target }} --pool ${{ env.pool }} --${{ matrix.type }}

--- a/.github/workflows/rsv.yaml
+++ b/.github/workflows/rsv.yaml
@@ -19,8 +19,14 @@ env:
 
 jobs:
 
-  unitary-pool:
+  test:
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [pools, zaps]
+        type: [unitary, integration]
 
     steps:
     - uses: actions/checkout@v2
@@ -50,70 +56,4 @@ jobs:
         pip install -r requirements.txt
 
     - name: Run Tests
-      run: brownie test tests/pools/common/unitary --pool ${{ env.pool }}
-
-  integration:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache Compiler Installations
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.solcx
-          ~/.vvm
-        key: compiler-cache
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-
-    - name: Install Ganache
-      run: npm install
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install Requirements
-      run: |
-        pip install wheel
-        pip install -r requirements.txt
-
-    - name: Run Tests
-      run: pytest tests/pools/common/integration --pool ${{ env.pool }}
-
-  unitary-zap:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache Compiler Installations
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.solcx
-          ~/.vvm
-        key: compiler-cache
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-
-    - name: Install Ganache
-      run: npm install
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install Requirements
-      run: |
-        pip install wheel
-        pip install -r requirements.txt
-
-    - name: Run Tests
-      run: brownie test tests/zaps/common --pool ${{ env.pool }}
+      run: brownie test tests/${{ matrix.target }} --pool ${{ env.pool }} --${{ matrix.type }}

--- a/.github/workflows/sbtc.yaml
+++ b/.github/workflows/sbtc.yaml
@@ -19,8 +19,14 @@ env:
 
 jobs:
 
-  unitary-pool:
+  test:
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [pools, zaps]
+        type: [unitary, integration]
 
     steps:
     - uses: actions/checkout@v2
@@ -50,37 +56,4 @@ jobs:
         pip install -r requirements.txt
 
     - name: Run Tests
-      run: brownie test tests/pools/common/unitary --pool ${{ env.pool }}
-
-  integration:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache Compiler Installations
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.solcx
-          ~/.vvm
-        key: compiler-cache
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-
-    - name: Install Ganache
-      run: npm install
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install Requirements
-      run: |
-        pip install wheel
-        pip install -r requirements.txt
-
-    - name: Run Tests
-      run: pytest tests/pools/common/integration --pool ${{ env.pool }}
+      run: brownie test tests/${{ matrix.target }} --pool ${{ env.pool }} --${{ matrix.type }}

--- a/.github/workflows/snow.yaml
+++ b/.github/workflows/snow.yaml
@@ -19,8 +19,14 @@ env:
 
 jobs:
 
-  unitary-pool:
+  test:
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [pools, zaps]
+        type: [unitary, integration]
 
     steps:
     - uses: actions/checkout@v2
@@ -50,70 +56,4 @@ jobs:
         pip install -r requirements.txt
 
     - name: Run Tests
-      run: brownie test tests/pools/common/unitary --pool ${{ env.pool }}
-
-  integration:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache Compiler Installations
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.solcx
-          ~/.vvm
-        key: compiler-cache
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-
-    - name: Install Ganache
-      run: npm install
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install Requirements
-      run: |
-        pip install wheel
-        pip install -r requirements.txt
-
-    - name: Run Tests
-      run: pytest tests/pools/common/integration --pool ${{ env.pool }}
-
-  unitary-zap:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache Compiler Installations
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.solcx
-          ~/.vvm
-        key: compiler-cache
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-
-    - name: Install Ganache
-      run: npm install
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install Requirements
-      run: |
-        pip install wheel
-        pip install -r requirements.txt
-
-    - name: Run Tests
-      run: brownie test tests/zaps/common --pool ${{ env.pool }}
+      run: brownie test tests/${{ matrix.target }} --pool ${{ env.pool }} --${{ matrix.type }}

--- a/.github/workflows/susd.yaml
+++ b/.github/workflows/susd.yaml
@@ -19,8 +19,14 @@ env:
 
 jobs:
 
-  unitary-pool:
+  test:
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [pools, zaps]
+        type: [unitary, integration]
 
     steps:
     - uses: actions/checkout@v2
@@ -50,70 +56,4 @@ jobs:
         pip install -r requirements.txt
 
     - name: Run Tests
-      run: brownie test tests/pools/common/unitary --pool ${{ env.pool }}
-
-  integration:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache Compiler Installations
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.solcx
-          ~/.vvm
-        key: compiler-cache
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-
-    - name: Install Ganache
-      run: npm install
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install Requirements
-      run: |
-        pip install wheel
-        pip install -r requirements.txt
-
-    - name: Run Tests
-      run: pytest tests/pools/common/integration --pool ${{ env.pool }}
-
-  unitary-zap:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache Compiler Installations
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.solcx
-          ~/.vvm
-        key: compiler-cache
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-
-    - name: Install Ganache
-      run: npm install
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install Requirements
-      run: |
-        pip install wheel
-        pip install -r requirements.txt
-
-    - name: Run Tests
-      run: brownie test tests/zaps/common --pool ${{ env.pool }}
+      run: brownie test tests/${{ matrix.target }} --pool ${{ env.pool }} --${{ matrix.type }}

--- a/.github/workflows/tbtc.yaml
+++ b/.github/workflows/tbtc.yaml
@@ -19,8 +19,14 @@ env:
 
 jobs:
 
-  unitary-pool:
+  test:
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [pools, zaps]
+        type: [unitary, integration]
 
     steps:
     - uses: actions/checkout@v2
@@ -50,70 +56,4 @@ jobs:
         pip install -r requirements.txt
 
     - name: Run Tests
-      run: brownie test tests/pools/common/unitary --pool ${{ env.pool }}
-
-  integration:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache Compiler Installations
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.solcx
-          ~/.vvm
-        key: compiler-cache
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-
-    - name: Install Ganache
-      run: npm install
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install Requirements
-      run: |
-        pip install wheel
-        pip install -r requirements.txt
-
-    - name: Run Tests
-      run: pytest tests/pools/common/integration --pool ${{ env.pool }}
-
-  unitary-zap:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache Compiler Installations
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.solcx
-          ~/.vvm
-        key: compiler-cache
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-
-    - name: Install Ganache
-      run: npm install
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install Requirements
-      run: |
-        pip install wheel
-        pip install -r requirements.txt
-
-    - name: Run Tests
-      run: brownie test tests/zaps/common --pool ${{ env.pool }}
+      run: brownie test tests/${{ matrix.target }} --pool ${{ env.pool }} --${{ matrix.type }}

--- a/.github/workflows/template-base.yaml
+++ b/.github/workflows/template-base.yaml
@@ -19,8 +19,14 @@ env:
 
 jobs:
 
-  unitary-pool:
+  test:
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [pools, zaps]
+        type: [unitary, integration]
 
     steps:
     - uses: actions/checkout@v2
@@ -50,37 +56,4 @@ jobs:
         pip install -r requirements.txt
 
     - name: Run Tests
-      run: brownie test tests/pools/common/unitary --pool ${{ env.pool }}
-
-  integration:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache Compiler Installations
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.solcx
-          ~/.vvm
-        key: compiler-cache
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-
-    - name: Install Ganache
-      run: npm install
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install Requirements
-      run: |
-        pip install wheel
-        pip install -r requirements.txt
-
-    - name: Run Tests
-      run: pytest tests/pools/common/integration --pool ${{ env.pool }}
+      run: brownie test tests/${{ matrix.target }} --pool ${{ env.pool }} --${{ matrix.type }}

--- a/.github/workflows/template-meta.yaml
+++ b/.github/workflows/template-meta.yaml
@@ -19,8 +19,14 @@ env:
 
 jobs:
 
-  unitary-pool:
+  test:
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [pools, zaps]
+        type: [unitary, integration]
 
     steps:
     - uses: actions/checkout@v2
@@ -50,70 +56,4 @@ jobs:
         pip install -r requirements.txt
 
     - name: Run Tests
-      run: brownie test tests/pools/common/unitary --pool ${{ env.pool }}
-
-  integration:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache Compiler Installations
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.solcx
-          ~/.vvm
-        key: compiler-cache
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-
-    - name: Install Ganache
-      run: npm install
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install Requirements
-      run: |
-        pip install wheel
-        pip install -r requirements.txt
-
-    - name: Run Tests
-      run: pytest tests/pools/common/integration --pool ${{ env.pool }}
-
-  unitary-zap:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache Compiler Installations
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.solcx
-          ~/.vvm
-        key: compiler-cache
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-
-    - name: Install Ganache
-      run: npm install
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install Requirements
-      run: |
-        pip install wheel
-        pip install -r requirements.txt
-
-    - name: Run Tests
-      run: brownie test tests/zaps/common --pool ${{ env.pool }}
+      run: brownie test tests/${{ matrix.target }} --pool ${{ env.pool }} --${{ matrix.type }}

--- a/.github/workflows/template-y.yaml
+++ b/.github/workflows/template-y.yaml
@@ -19,8 +19,14 @@ env:
 
 jobs:
 
-  unitary-pool:
+  test:
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [pools, zaps]
+        type: [unitary, integration]
 
     steps:
     - uses: actions/checkout@v2
@@ -50,70 +56,4 @@ jobs:
         pip install -r requirements.txt
 
     - name: Run Tests
-      run: brownie test tests/pools/common/unitary --pool ${{ env.pool }}
-
-  integration:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache Compiler Installations
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.solcx
-          ~/.vvm
-        key: compiler-cache
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-
-    - name: Install Ganache
-      run: npm install
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install Requirements
-      run: |
-        pip install wheel
-        pip install -r requirements.txt
-
-    - name: Run Tests
-      run: pytest tests/pools/common/integration --pool ${{ env.pool }}
-
-  unitary-zap:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache Compiler Installations
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.solcx
-          ~/.vvm
-        key: compiler-cache
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-
-    - name: Install Ganache
-      run: npm install
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install Requirements
-      run: |
-        pip install wheel
-        pip install -r requirements.txt
-
-    - name: Run Tests
-      run: brownie test tests/zaps/common --pool ${{ env.pool }}
+      run: brownie test tests/${{ matrix.target }} --pool ${{ env.pool }} --${{ matrix.type }}

--- a/.github/workflows/usdk.yaml
+++ b/.github/workflows/usdk.yaml
@@ -19,8 +19,14 @@ env:
 
 jobs:
 
-  unitary-pool:
+  test:
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [pools, zaps]
+        type: [unitary, integration]
 
     steps:
     - uses: actions/checkout@v2
@@ -50,70 +56,4 @@ jobs:
         pip install -r requirements.txt
 
     - name: Run Tests
-      run: brownie test tests/pools/common/unitary --pool ${{ env.pool }}
-
-  integration:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache Compiler Installations
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.solcx
-          ~/.vvm
-        key: compiler-cache
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-
-    - name: Install Ganache
-      run: npm install
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install Requirements
-      run: |
-        pip install wheel
-        pip install -r requirements.txt
-
-    - name: Run Tests
-      run: pytest tests/pools/common/integration --pool ${{ env.pool }}
-
-  unitary-zap:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache Compiler Installations
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.solcx
-          ~/.vvm
-        key: compiler-cache
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-
-    - name: Install Ganache
-      run: npm install
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install Requirements
-      run: |
-        pip install wheel
-        pip install -r requirements.txt
-
-    - name: Run Tests
-      run: brownie test tests/zaps/common --pool ${{ env.pool }}
+      run: brownie test tests/${{ matrix.target }} --pool ${{ env.pool }} --${{ matrix.type }}

--- a/.github/workflows/usdn.yaml
+++ b/.github/workflows/usdn.yaml
@@ -19,8 +19,14 @@ env:
 
 jobs:
 
-  unitary-pool:
+  test:
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [pools, zaps]
+        type: [unitary, integration]
 
     steps:
     - uses: actions/checkout@v2
@@ -50,70 +56,4 @@ jobs:
         pip install -r requirements.txt
 
     - name: Run Tests
-      run: brownie test tests/pools/common/unitary --pool ${{ env.pool }}
-
-  integration:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache Compiler Installations
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.solcx
-          ~/.vvm
-        key: compiler-cache
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-
-    - name: Install Ganache
-      run: npm install
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install Requirements
-      run: |
-        pip install wheel
-        pip install -r requirements.txt
-
-    - name: Run Tests
-      run: pytest tests/pools/common/integration --pool ${{ env.pool }}
-
-  unitary-zap:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache Compiler Installations
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.solcx
-          ~/.vvm
-        key: compiler-cache
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-
-    - name: Install Ganache
-      run: npm install
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install Requirements
-      run: |
-        pip install wheel
-        pip install -r requirements.txt
-
-    - name: Run Tests
-      run: brownie test tests/zaps/common --pool ${{ env.pool }}
+      run: brownie test tests/${{ matrix.target }} --pool ${{ env.pool }} --${{ matrix.type }}

--- a/.github/workflows/usdt.yaml
+++ b/.github/workflows/usdt.yaml
@@ -19,8 +19,14 @@ env:
 
 jobs:
 
-  unitary-pool:
+  test:
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [pools, zaps]
+        type: [unitary, integration]
 
     steps:
     - uses: actions/checkout@v2
@@ -50,70 +56,4 @@ jobs:
         pip install -r requirements.txt
 
     - name: Run Tests
-      run: brownie test tests/pools/common/unitary --pool ${{ env.pool }}
-
-  integration:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache Compiler Installations
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.solcx
-          ~/.vvm
-        key: compiler-cache
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-
-    - name: Install Ganache
-      run: npm install
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install Requirements
-      run: |
-        pip install wheel
-        pip install -r requirements.txt
-
-    - name: Run Tests
-      run: pytest tests/pools/common/integration --pool ${{ env.pool }}
-
-  unitary-zap:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache Compiler Installations
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.solcx
-          ~/.vvm
-        key: compiler-cache
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-
-    - name: Install Ganache
-      run: npm install
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install Requirements
-      run: |
-        pip install wheel
-        pip install -r requirements.txt
-
-    - name: Run Tests
-      run: brownie test tests/zaps/common --pool ${{ env.pool }}
+      run: brownie test tests/${{ matrix.target }} --pool ${{ env.pool }} --${{ matrix.type }}

--- a/.github/workflows/y.yaml
+++ b/.github/workflows/y.yaml
@@ -19,8 +19,14 @@ env:
 
 jobs:
 
-  unitary-pool:
+  test:
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [pools, zaps]
+        type: [unitary, integration]
 
     steps:
     - uses: actions/checkout@v2
@@ -50,70 +56,4 @@ jobs:
         pip install -r requirements.txt
 
     - name: Run Tests
-      run: brownie test tests/pools/common/unitary --pool ${{ env.pool }}
-
-  integration:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache Compiler Installations
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.solcx
-          ~/.vvm
-        key: compiler-cache
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-
-    - name: Install Ganache
-      run: npm install
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install Requirements
-      run: |
-        pip install wheel
-        pip install -r requirements.txt
-
-    - name: Run Tests
-      run: pytest tests/pools/common/integration --pool ${{ env.pool }}
-
-  unitary-zap:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache Compiler Installations
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.solcx
-          ~/.vvm
-        key: compiler-cache
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-
-    - name: Install Ganache
-      run: npm install
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install Requirements
-      run: |
-        pip install wheel
-        pip install -r requirements.txt
-
-    - name: Run Tests
-      run: brownie test tests/zaps/common --pool ${{ env.pool }}
+      run: brownie test tests/${{ matrix.target }} --pool ${{ env.pool }} --${{ matrix.type }}

--- a/tests/README.md
+++ b/tests/README.md
@@ -18,6 +18,7 @@ Test cases for Curve pools.
 
 * Tests are organized by general category, then split between unitary and integration tests.
 * Common tests for all pools are located in [`tests/pools/common`](pools/common), for zaps in [`tests/zaps/common`](zaps/common).
+* Common metapool tests are located at [`tests/pools/meta`](pools/meta), for zaps in [`tests/zaps/meta`](zaps/meta).
 * Valid pool names are the names of the subdirectories within [`contracts/pools`](../contracts/pools).
 * For pool templates, prepend `template-` to the subdirectory names within [`contracts/pool-templates`](../contracts/pool-templates). For example, the base template is `template-base`.
 
@@ -29,13 +30,21 @@ To run the entire suite:
 brownie test
 ```
 
-To run tests on a specific pool:
+Note that this executes over 10,000 tests and may take a significant amount of time to finish.
+
+### Test Collection Filters
+
+The test suite is divided into several logical categories. Tests may be filtered using one or more flags:
+
+* `--pool <POOL NAME>`: only run tests against a specific pool
+* `--integration`: only run integration tests (tests within an `integration/` subdirectory)
+* `--unitary`: only run unit tests (tests NOT found in an `integration/` subdirectory)
+
+For example, to only run the unit tests for 3pool:
 
 ```bash
-pytest tests --pool <POOL NAME>
+brownie test --pool 3pool --unitary
 ```
-
-You can optionally include the `--coverage` flag to view a coverage report upon completion of the tests.
 
 ## Testing against a forked mainnet
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -251,6 +251,13 @@ def pytest_collection_modifyitems(config, items):
     config.pluginmanager.get_plugin("terminalreporter")._numcollected = len(items)
 
 
+@pytest.hookimpl(trylast=True)
+def pytest_sessionfinish(session, exitstatus):
+    if exitstatus == pytest.ExitCode.NO_TESTS_COLLECTED:
+        # because of how tests are filtered in the CI, we treat "no tests collected" as passing
+        session.exitstatus = pytest.ExitCode.OK
+
+
 # isolation setup
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,8 @@ _pooldata = {}
 
 def pytest_addoption(parser):
     parser.addoption("--pool", help="comma-separated list of pools to target",)
+    parser.addoption("--unitary", action="store_true", help="only run unit tests")
+    parser.addoption("--integration", action="store_true", help="only run integration tests")
 
 
 def pytest_configure(config):
@@ -93,6 +95,46 @@ def pytest_sessionstart():
             data["base_pool"] = base_data
 
 
+def pytest_ignore_collect(path, config):
+    project = get_loaded_projects()[0]
+    path = Path(path).relative_to(project._path)
+    path_parts = path.parts[1:-1]
+
+    if path.is_dir():
+        return None
+
+    # always collect fixtures
+    if path_parts[:1] == ("fixtures",):
+        return None
+
+    # with the `--unitary` flag, skip any tests in an `integration` subdirectory
+    if config.getoption("unitary") and "integration" in path_parts:
+        return True
+
+    # with the `--integration` flag, skip any tests NOT in an `integration` subdirectory
+    if config.getoption("integration") and "integration" not in path_parts:
+        return True
+
+    if config.getoption("pool") and path_parts:
+        # with a specific pool targeted, only run pool and zap tests
+        if path_parts[0] not in ("pools", "zaps"):
+            return True
+
+        # always run common tests
+        if path_parts[1] == "common":
+            return None
+
+        target_pools = config.getoption("pool").split(',')
+
+        # only include metapool tests if at least one targeted pool is a metapool
+        if path_parts[1] == "meta":
+            return next((None for i in target_pools if _pooldata[i].get("base_pool")), True)
+
+        # filter other pool-specific folders
+        if path_parts[1] not in target_pools:
+            return True
+
+
 def pytest_generate_tests(metafunc):
     project = get_loaded_projects()[0]
     itercoins_bound = max(len(i['coins']) for i in _pooldata.values())
@@ -101,18 +143,21 @@ def pytest_generate_tests(metafunc):
         # parametrize `pool_data`
         test_path = Path(metafunc.definition.fspath).relative_to(project._path)
         if test_path.parts[1] in ("pools", "zaps"):
-            # parametrize common pool/zap tests to run against all pools
-            if test_path.parts[2] == "common":
+            if test_path.parts[2] in ("common", "meta"):
+                # parametrize common pool/zap tests to run against all pools
                 if metafunc.config.getoption("pool"):
                     params = metafunc.config.getoption("pool").split(',')
                 else:
                     params = list(_pooldata)
-                if test_path.parts[1] == "zaps":
-                    # for zap tests, filter by pools that have a Deposit contract
-                    params = [i for i in params if _pooldata[i].get("zap_contract")]
+                if test_path.parts[2] == "meta":
+                    params = [i for i in params if _pooldata[i].get("base_pool")]
             else:
                 # run targetted pool/zap tests against only the specific pool
                 params = [test_path.parts[2]]
+
+            if test_path.parts[1] == "zaps":
+                # for zap tests, filter by pools that have a Deposit contract
+                params = [i for i in params if _pooldata[i].get("zap_contract")]
         else:
             # pool tests outside `tests/pools` or `tests/zaps` will only run when
             # a target pool is explicitly declared

--- a/tests/test_gas.py
+++ b/tests/test_gas.py
@@ -1,7 +1,10 @@
 import itertools
 import pytest
 
-pytestmark = pytest.mark.usefixtures("mint_alice", "approve_alice", "mint_bob", "approve_bob")
+
+@pytest.fixture(scope="module", autouse=True)
+def setup(mint_alice, approve_alice, mint_bob, approve_bob, set_fees):
+    set_fees(4000000, 5000000000, include_meta=True)
 
 
 def test_swap_gas(


### PR DESCRIPTION
### What I did
Improve test filtering logic and streamling the CI workflow.

Tests may now be filtered using one or more flags:

* `--pool <POOL NAME>`: only run tests against a specific pool
* `--integration`: only run integration tests (tests within an `integration/` subdirectory)
* `--unitary`: only run unit tests (tests NOT found in an `integration/` subdirectory)

Similar to the `common` subdirectory, tests placed in `pools/meta` or `zaps/meta` are only run against metapools.

### How I did it
* Filtering is handled with the `pytest_ignore_collect` hookpoint.
* Workflows are streamlined using a 2-dimensional matrix.
* For cases where no tests are collected (e.g. zap tests on a non-lending pool), `pytest_sessionfinish` is used to ensure an exit code of zero. This way the job can still be executed from the CI, so each workflow file can be more standardized.

### How to verify it
Watch 130+ jobs run in the CI.