### PR TITLE
Fix: slippage when withdrawing via metapool zap

### DIFF
--- a/contracts/pool-templates/meta/DepositTemplateMeta.vy
+++ b/contracts/pool-templates/meta/DepositTemplateMeta.vy
@@ -41,7 +41,7 @@ N_ALL_COINS: constant(int128) = N_COINS + BASE_N_COINS - 1
 FEE_ASSET: constant(address) = 0xdAC17F958D2ee523a2206206994597C13D831ec7
 
 FEE_DENOMINATOR: constant(uint256) = 10 ** 10
-FEE_IMPRECISION: constant(uint256) = 25 * 10 ** 8  # % of the fee
+FEE_IMPRECISION: constant(uint256) = 100 * 10 ** 8  # % of the fee
 
 
 pool: public(address)

--- a/contracts/pools/gusd/DepositGUSD.vy
+++ b/contracts/pools/gusd/DepositGUSD.vy
@@ -1,4 +1,4 @@
-# @version 0.2.5
+# @version 0.2.7
 """
 @title "Zap" Depositer for Curve GUSD pool
 @author Curve.Fi
@@ -34,11 +34,11 @@ MAX_COIN: constant(int128) = N_COINS-1
 BASE_N_COINS: constant(int128) = 3
 N_ALL_COINS: constant(int128) = N_COINS + BASE_N_COINS - 1
 
-# An asset shich may have a transfer fee (USDT)
+# An asset which may have a transfer fee (USDT)
 FEE_ASSET: constant(address) = 0xdAC17F958D2ee523a2206206994597C13D831ec7
 
 FEE_DENOMINATOR: constant(uint256) = 10 ** 10
-FEE_IMPRECISION: constant(uint256) = 25 * 10 ** 8  # % of the fee
+FEE_IMPRECISION: constant(uint256) = 100 * 10 ** 8  # % of the fee
 
 
 pool: public(address)
@@ -258,7 +258,8 @@ def remove_liquidity_imbalance(amounts: uint256[N_ALL_COINS], max_burn_amount: u
     """
     @notice Withdraw coins from the pool in an imbalanced amount
     @param amounts List of amounts of underlying coins to withdraw
-    @param max_burn_amount Maximum amount of LP token to burn in the withdrawal
+    @param max_burn_amount Maximum amount of LP token to burn in the withdrawal.
+                           This value cannot exceed the caller's LP token balance.
     @return Actual amount of the LP token burned in the withdrawal
     """
     _base_pool: address = self.base_pool

--- a/contracts/pools/husd/DepositHUSD.vy
+++ b/contracts/pools/husd/DepositHUSD.vy
@@ -1,4 +1,4 @@
-# @version 0.2.5
+# @version 0.2.7
 """
 @title "Zap" Depositer for Curve HUSD pool
 @author Curve.Fi
@@ -34,11 +34,11 @@ MAX_COIN: constant(int128) = N_COINS-1
 BASE_N_COINS: constant(int128) = 3
 N_ALL_COINS: constant(int128) = N_COINS + BASE_N_COINS - 1
 
-# An asset shich may have a transfer fee (USDT)
+# An asset which may have a transfer fee (USDT)
 FEE_ASSET: constant(address) = 0xdAC17F958D2ee523a2206206994597C13D831ec7
 
 FEE_DENOMINATOR: constant(uint256) = 10 ** 10
-FEE_IMPRECISION: constant(uint256) = 25 * 10 ** 8  # % of the fee
+FEE_IMPRECISION: constant(uint256) = 100 * 10 ** 8  # % of the fee
 
 
 pool: public(address)
@@ -258,7 +258,8 @@ def remove_liquidity_imbalance(amounts: uint256[N_ALL_COINS], max_burn_amount: u
     """
     @notice Withdraw coins from the pool in an imbalanced amount
     @param amounts List of amounts of underlying coins to withdraw
-    @param max_burn_amount Maximum amount of LP token to burn in the withdrawal
+    @param max_burn_amount Maximum amount of LP token to burn in the withdrawal.
+                           This value cannot exceed the caller's LP token balance.
     @return Actual amount of the LP token burned in the withdrawal
     """
     _base_pool: address = self.base_pool

--- a/contracts/pools/linkusd/DepositLinkUSD.vy
+++ b/contracts/pools/linkusd/DepositLinkUSD.vy
@@ -1,4 +1,4 @@
-# @version 0.2.5
+# @version 0.2.7
 """
 @title "Zap" Depositer for Curve LinkUSD pool
 @author Curve.Fi
@@ -38,7 +38,7 @@ N_ALL_COINS: constant(int128) = N_COINS + BASE_N_COINS - 1
 FEE_ASSET: constant(address) = 0xdAC17F958D2ee523a2206206994597C13D831ec7
 
 FEE_DENOMINATOR: constant(uint256) = 10 ** 10
-FEE_IMPRECISION: constant(uint256) = 25 * 10 ** 8  # % of the fee
+FEE_IMPRECISION: constant(uint256) = 100 * 10 ** 8  # % of the fee
 
 
 pool: public(address)
@@ -258,7 +258,8 @@ def remove_liquidity_imbalance(amounts: uint256[N_ALL_COINS], max_burn_amount: u
     """
     @notice Withdraw coins from the pool in an imbalanced amount
     @param amounts List of amounts of underlying coins to withdraw
-    @param max_burn_amount Maximum amount of LP token to burn in the withdrawal
+    @param max_burn_amount Maximum amount of LP token to burn in the withdrawal.
+                           This value cannot exceed the caller's LP token balance.
     @return Actual amount of the LP token burned in the withdrawal
     """
     _base_pool: address = self.base_pool

--- a/contracts/pools/musd/DepositMUSD.vy
+++ b/contracts/pools/musd/DepositMUSD.vy
@@ -1,4 +1,4 @@
-# @version 0.2.5
+# @version 0.2.7
 """
 @title "Zap" Depositer for Curve MUSD pool
 @author Curve.Fi
@@ -34,11 +34,11 @@ MAX_COIN: constant(int128) = N_COINS-1
 BASE_N_COINS: constant(int128) = 3
 N_ALL_COINS: constant(int128) = N_COINS + BASE_N_COINS - 1
 
-# An asset shich may have a transfer fee (USDT)
+# An asset which may have a transfer fee (USDT)
 FEE_ASSET: constant(address) = 0xdAC17F958D2ee523a2206206994597C13D831ec7
 
 FEE_DENOMINATOR: constant(uint256) = 10 ** 10
-FEE_IMPRECISION: constant(uint256) = 25 * 10 ** 8  # % of the fee
+FEE_IMPRECISION: constant(uint256) = 100 * 10 ** 8  # % of the fee
 
 
 pool: public(address)
@@ -258,7 +258,8 @@ def remove_liquidity_imbalance(amounts: uint256[N_ALL_COINS], max_burn_amount: u
     """
     @notice Withdraw coins from the pool in an imbalanced amount
     @param amounts List of amounts of underlying coins to withdraw
-    @param max_burn_amount Maximum amount of LP token to burn in the withdrawal
+    @param max_burn_amount Maximum amount of LP token to burn in the withdrawal.
+                           This value cannot exceed the caller's LP token balance.
     @return Actual amount of the LP token burned in the withdrawal
     """
     _base_pool: address = self.base_pool

--- a/contracts/pools/rsv/DepositRSV.vy
+++ b/contracts/pools/rsv/DepositRSV.vy
@@ -1,4 +1,4 @@
-# @version 0.2.5
+# @version 0.2.7
 """
 @title "Zap" Depositer for Curve RSV pool
 @author Curve.Fi
@@ -38,7 +38,7 @@ N_ALL_COINS: constant(int128) = N_COINS + BASE_N_COINS - 1
 FEE_ASSET: constant(address) = 0xdAC17F958D2ee523a2206206994597C13D831ec7
 
 FEE_DENOMINATOR: constant(uint256) = 10 ** 10
-FEE_IMPRECISION: constant(uint256) = 25 * 10 ** 8  # % of the fee
+FEE_IMPRECISION: constant(uint256) = 100 * 10 ** 8  # % of the fee
 
 
 pool: public(address)
@@ -258,7 +258,8 @@ def remove_liquidity_imbalance(amounts: uint256[N_ALL_COINS], max_burn_amount: u
     """
     @notice Withdraw coins from the pool in an imbalanced amount
     @param amounts List of amounts of underlying coins to withdraw
-    @param max_burn_amount Maximum amount of LP token to burn in the withdrawal
+    @param max_burn_amount Maximum amount of LP token to burn in the withdrawal.
+                           This value cannot exceed the caller's LP token balance.
     @return Actual amount of the LP token burned in the withdrawal
     """
     _base_pool: address = self.base_pool

--- a/contracts/pools/tbtc/DepositTBTC.vy
+++ b/contracts/pools/tbtc/DepositTBTC.vy
@@ -34,9 +34,6 @@ MAX_COIN: constant(int128) = N_COINS-1
 BASE_N_COINS: constant(int128) = 3
 N_ALL_COINS: constant(int128) = N_COINS + BASE_N_COINS - 1
 
-# An asset which may have a transfer fee (USDT)
-FEE_ASSET: constant(address) = 0xEB4C2781e4ebA804CE9a9803C67d0893436bB27D
-
 FEE_DENOMINATOR: constant(uint256) = 10 ** 10
 FEE_IMPRECISION: constant(uint256) = 100 * 10 ** 8  # % of the fee
 
@@ -134,13 +131,6 @@ def add_liquidity(amounts: uint256[N_ALL_COINS], min_mint_amount: uint256) -> ui
         if len(_response) > 0:
             assert convert(_response, bool)  # dev: failed transfer
         # end "safeTransferFrom"
-        # Handle potential Tether fees
-        if coin == FEE_ASSET:
-            amount = ERC20(FEE_ASSET).balanceOf(self)
-            if i < MAX_COIN:
-                meta_amounts[i] = amount
-            else:
-                base_amounts[i - MAX_COIN] = amount
 
     # Deposit to the base pool
     if deposit_base:

--- a/contracts/pools/tbtc/DepositTBTC.vy
+++ b/contracts/pools/tbtc/DepositTBTC.vy
@@ -34,11 +34,11 @@ MAX_COIN: constant(int128) = N_COINS-1
 BASE_N_COINS: constant(int128) = 3
 N_ALL_COINS: constant(int128) = N_COINS + BASE_N_COINS - 1
 
-# An asset shich may have a transfer fee (USDT)
+# An asset which may have a transfer fee (USDT)
 FEE_ASSET: constant(address) = 0xEB4C2781e4ebA804CE9a9803C67d0893436bB27D
 
 FEE_DENOMINATOR: constant(uint256) = 10 ** 10
-FEE_IMPRECISION: constant(uint256) = 25 * 10 ** 8  # % of the fee
+FEE_IMPRECISION: constant(uint256) = 100 * 10 ** 8  # % of the fee
 
 
 pool: public(address)
@@ -258,7 +258,8 @@ def remove_liquidity_imbalance(amounts: uint256[N_ALL_COINS], max_burn_amount: u
     """
     @notice Withdraw coins from the pool in an imbalanced amount
     @param amounts List of amounts of underlying coins to withdraw
-    @param max_burn_amount Maximum amount of LP token to burn in the withdrawal
+    @param max_burn_amount Maximum amount of LP token to burn in the withdrawal.
+                           This value cannot exceed the caller's LP token balance.
     @return Actual amount of the LP token burned in the withdrawal
     """
     _base_pool: address = self.base_pool

--- a/contracts/pools/usdk/DepositUSDK.vy
+++ b/contracts/pools/usdk/DepositUSDK.vy
@@ -1,4 +1,4 @@
-# @version 0.2.5
+# @version 0.2.7
 """
 @title "Zap" Depositer for Curve USDK pool
 @author Curve.Fi
@@ -34,11 +34,11 @@ MAX_COIN: constant(int128) = N_COINS-1
 BASE_N_COINS: constant(int128) = 3
 N_ALL_COINS: constant(int128) = N_COINS + BASE_N_COINS - 1
 
-# An asset shich may have a transfer fee (USDT)
+# An asset which may have a transfer fee (USDT)
 FEE_ASSET: constant(address) = 0xdAC17F958D2ee523a2206206994597C13D831ec7
 
 FEE_DENOMINATOR: constant(uint256) = 10 ** 10
-FEE_IMPRECISION: constant(uint256) = 25 * 10 ** 8  # % of the fee
+FEE_IMPRECISION: constant(uint256) = 100 * 10 ** 8  # % of the fee
 
 
 pool: public(address)
@@ -258,7 +258,8 @@ def remove_liquidity_imbalance(amounts: uint256[N_ALL_COINS], max_burn_amount: u
     """
     @notice Withdraw coins from the pool in an imbalanced amount
     @param amounts List of amounts of underlying coins to withdraw
-    @param max_burn_amount Maximum amount of LP token to burn in the withdrawal
+    @param max_burn_amount Maximum amount of LP token to burn in the withdrawal.
+                           This value cannot exceed the caller's LP token balance.
     @return Actual amount of the LP token burned in the withdrawal
     """
     _base_pool: address = self.base_pool

--- a/contracts/pools/usdn/DepositUSDN.vy
+++ b/contracts/pools/usdn/DepositUSDN.vy
@@ -1,4 +1,4 @@
-# @version 0.2.5
+# @version 0.2.7
 """
 @title "Zap" Depositer for Curve USDN pool
 @author Curve.Fi
@@ -34,11 +34,11 @@ MAX_COIN: constant(int128) = N_COINS-1
 BASE_N_COINS: constant(int128) = 3
 N_ALL_COINS: constant(int128) = N_COINS + BASE_N_COINS - 1
 
-# An asset shich may have a transfer fee (USDT)
+# An asset which may have a transfer fee (USDT)
 FEE_ASSET: constant(address) = 0xdAC17F958D2ee523a2206206994597C13D831ec7
 
 FEE_DENOMINATOR: constant(uint256) = 10 ** 10
-FEE_IMPRECISION: constant(uint256) = 25 * 10 ** 8  # % of the fee
+FEE_IMPRECISION: constant(uint256) = 100 * 10 ** 8  # % of the fee
 
 
 pool: public(address)
@@ -258,7 +258,8 @@ def remove_liquidity_imbalance(amounts: uint256[N_ALL_COINS], max_burn_amount: u
     """
     @notice Withdraw coins from the pool in an imbalanced amount
     @param amounts List of amounts of underlying coins to withdraw
-    @param max_burn_amount Maximum amount of LP token to burn in the withdrawal
+    @param max_burn_amount Maximum amount of LP token to burn in the withdrawal.
+                           This value cannot exceed the caller's LP token balance.
     @return Actual amount of the LP token burned in the withdrawal
     """
     _base_pool: address = self.base_pool

--- a/tests/zaps/meta/integration/test_remove_liquidity_imbalance_zap.py
+++ b/tests/zaps/meta/integration/test_remove_liquidity_imbalance_zap.py
@@ -1,0 +1,31 @@
+import pytest
+from brownie.test import given, strategy
+from hypothesis import settings
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup(alice, bob, pool_token, add_initial_liquidity, approve_zap, set_fees):
+    pool_token.transfer(bob, pool_token.balanceOf(alice), {'from': alice})
+    set_fees(4000000, 5000000000, include_meta=True)
+
+
+@given(
+    st_base=strategy('decimal[3]', min_value=0, max_value="0.49", unique=True, places=2),
+    st_zap=strategy('decimal[4]', min_value=0, max_value="0.99", unique=True, places=2),
+)
+@settings(max_examples=100)
+def test_remove_liquidity_imbalance(
+    bob, charlie, zap, pool_token, initial_amounts_underlying, base_swap, swap, st_base, st_zap
+):
+
+    # remove liquidity from base pool to leave it imbalanced
+    # st_base maxes at 49% because 50% of the total supply is with charlie
+    amounts = [int(base_swap.balances(i) * st_base[i]) for i in range(3)]
+    base_swap.remove_liquidity_imbalance(amounts, 2**256-1, {'from': charlie})
+
+    # attempt an imbalanced withdrawal from the base pool via the metapool zap
+    amounts = [int(initial_amounts_underlying[i] * st_zap[i]) for i in range(4)]
+    max_burn = pool_token.balanceOf(bob)
+
+    # we aren't worried about the amounts here, just that the function does not revert
+    zap.remove_liquidity_imbalance(amounts, max_burn, {'from': bob})


### PR DESCRIPTION
### What I did
Increase `FEE_IMPRECISION` in metapool zap contracts to avoid reverting tx's when withdrawing with significant slippage.

### How I did it
Magic :mage: 

### How to verify it
Run the tests. I added a parametrized test case to focus on imbalanced withdrawals.