### PR TITLE
test: move rate caching tests to meta folder

### DIFF
--- a/tests/pools/meta/test_rate_caching.py
+++ b/tests/pools/meta/test_rate_caching.py
@@ -1,10 +1,7 @@
 import pytest
 
 
-pytestmark = [
-    pytest.mark.skip_pool("busd", "compound", "hbtc", "pax", "ren", "sbtc", "susd", "usdt", "y"),
-    pytest.mark.usefixtures("add_initial_liquidity"),
-]
+pytestmark = pytest.mark.usefixtures("add_initial_liquidity")
 
 
 def test_virtual_price(chain, bob, swap, initial_amounts, n_coins):


### PR DESCRIPTION
### What I did
#77 introduced test filtering via the `meta` subdirectory.  This PR moves `test_rate_caching` to `pools/meta`, since rate caching is only tested for metapools.