### PR TITLE
Pool Templates: Follow style guide and add templates

### DIFF
--- a/.github/workflows/template-a.yaml
+++ b/.github/workflows/template-a.yaml
@@ -1,0 +1,56 @@
+name: template-a
+
+on:
+  pull_request:
+    paths:
+      - "tests/**/*.py"
+      - "contracts/pool-templates/a/**.vy"
+  push:
+    paths:
+      - "tests/**/*.py"
+      - "contracts/pool-templates/a/**.vy"
+
+env:
+  pool: "template-a"
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  NODE_OPTIONS: --max_old_space_size=4096
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [pools, zaps]
+        type: [unitary, integration]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cache Compiler Installations
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.solcx
+            ~/.vvm
+          key: compiler-cache
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+
+      - name: Install Ganache
+        run: npm install
+
+      - name: Setup Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install Requirements
+        run: |
+          pip install wheel
+          pip install -r requirements.txt
+
+      - name: Run Tests
+        run: brownie test tests/${{ matrix.target }} --pool ${{ env.pool }} --${{ matrix.type }}

--- a/.github/workflows/template-eth.yaml
+++ b/.github/workflows/template-eth.yaml
@@ -1,0 +1,56 @@
+name: template-eth
+
+on:
+  pull_request:
+    paths:
+      - "tests/**/*.py"
+      - "contracts/pool-templates/eth/**.vy"
+  push:
+    paths:
+      - "tests/**/*.py"
+      - "contracts/pool-templates/eth/**.vy"
+
+env:
+  pool: "template-eth"
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  NODE_OPTIONS: --max_old_space_size=4096
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [pools, zaps]
+        type: [unitary, integration]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cache Compiler Installations
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.solcx
+            ~/.vvm
+          key: compiler-cache
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+
+      - name: Install Ganache
+        run: npm install
+
+      - name: Setup Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install Requirements
+        run: |
+          pip install wheel
+          pip install -r requirements.txt
+
+      - name: Run Tests
+        run: brownie test tests/${{ matrix.target }} --pool ${{ env.pool }} --${{ matrix.type }}

--- a/contracts/pool-templates/README.md
+++ b/contracts/pool-templates/README.md
@@ -6,9 +6,11 @@ Contract templates used as the basis for future pools.
 
 Each subdirectory holds contracts and other files specific to a single Curve pool template.
 
-* [`base`]: Minimal pool implementation optimized for no lending
-* [`meta`]: Metapool implementation for swapping base assets against a Curve LP token
-* [`y`]: Pool implementation with yearn-style lending
+- [`a`]: Pool implementation with aToken-style lending (i.e., interest accrues as balance increases)
+- [`base`]: Minimal pool implementation optimized for no lending
+- [`eth`]: Pool implementation with ETH
+- [`meta`]: Metapool implementation for swapping base assets against a Curve LP token
+- [`y`]: Pool implementation with yearn-style lending (i.e., interest accrues as rate increases)
 
 ## Development
 
@@ -16,16 +18,16 @@ Each subdirectory holds contracts and other files specific to a single Curve poo
 
 Contracts in this subdirectory contain special triple-dunder variables which are modified according to the quantity and properties of each stablecoin in a pool.
 
-* `___USE_LENDING___`: Array of booleans indicating whether each underlying coin in the pool is lent on the associated lending protocol
-* `___N_COINS___`: The number of coins within the pool
-* `___PRECISION_MUL___`: Array of integers that coin balances are multiplied by in order to adjust their precision to 18 decimal places
-* `___RATES___`: Array of integers indicating the relative value of `1e18` tokens for each stablecoin
+- `___USE_LENDING___`: Array of booleans indicating whether each underlying coin in the pool is lent on the associated lending protocol
+- `___N_COINS___`: The number of coins within the pool
+- `___PRECISION_MUL___`: Array of integers that coin balances are multiplied by in order to adjust their precision to 18 decimal places
+- `___RATES___`: Array of integers indicating the relative value of `1e18` tokens for each stablecoin
 
 Metapools also make use of the following variables:
 
-* `___BASE_N_COINS___`: The number of coins within the base pool
-* `___BASE_PRECISION_MUL___`: Array of integers that base coin balances are multiplied by to adjust their precision to 18 decimal places
-* `___BASE_RATES___`: Array of integers indicating the relative walue of `1e18` tokens for each base pool stablecoin
+- `___BASE_N_COINS___`: The number of coins within the base pool
+- `___BASE_PRECISION_MUL___`: Array of integers that base coin balances are multiplied by to adjust their precision to 18 decimal places
+- `___BASE_RATES___`: Array of integers indicating the relative walue of `1e18` tokens for each base pool stablecoin
 
 These variables are substituted out at compile-time. To set the values, edit the `pooldata.json` file within the template directory.
 
@@ -46,3 +48,4 @@ The layout of a template's `pooldata.json` is similar to that of an actual pool,
 }
 ```
 
+_Note_: For `y` and `a` pools, the implementor may have to remove/change some small parts in the template code which is specific to `yearn` and `aave` pools.

--- a/contracts/pool-templates/a/SwapTemplateA.vy
+++ b/contracts/pool-templates/a/SwapTemplateA.vy
@@ -1,0 +1,1138 @@
+# @version 0.2.8
+"""
+@title StableSwap
+@author Curve.Fi
+@license Copyright (c) Curve.Fi, 2020 - all rights reserved
+@notice Pool implementation with aToken-style lending
+@dev This contract is only a template, pool-specific constants
+     must be set prior to compiling. Note that this template is
+     currently compatible with aTokens (Aave) and that for other
+     protocols selected parts in the code may need to be changed.
+"""
+
+from vyper.interfaces import ERC20
+
+
+interface LendingPool:
+    def withdraw(_underlying_asset: address, _amount: uint256, _receiver: address): nonpayable
+
+interface CurveToken:
+    def mint(_to: address, _value: uint256) -> bool: nonpayable
+    def burnFrom(_to: address, _value: uint256) -> bool: nonpayable
+
+
+# Events
+event TokenExchange:
+    buyer: indexed(address)
+    sold_id: int128
+    tokens_sold: uint256
+    bought_id: int128
+    tokens_bought: uint256
+
+event TokenExchangeUnderlying:
+    buyer: indexed(address)
+    sold_id: int128
+    tokens_sold: uint256
+    bought_id: int128
+    tokens_bought: uint256
+
+event AddLiquidity:
+    provider: indexed(address)
+    token_amounts: uint256[N_COINS]
+    fees: uint256[N_COINS]
+    invariant: uint256
+    token_supply: uint256
+
+event RemoveLiquidity:
+    provider: indexed(address)
+    token_amounts: uint256[N_COINS]
+    fees: uint256[N_COINS]
+    token_supply: uint256
+
+event RemoveLiquidityOne:
+    provider: indexed(address)
+    token_amount: uint256
+    coin_amount: uint256
+
+event RemoveLiquidityImbalance:
+    provider: indexed(address)
+    token_amounts: uint256[N_COINS]
+    fees: uint256[N_COINS]
+    invariant: uint256
+    token_supply: uint256
+
+event CommitNewAdmin:
+    deadline: indexed(uint256)
+    admin: indexed(address)
+
+event NewAdmin:
+    admin: indexed(address)
+
+event CommitNewFee:
+    deadline: indexed(uint256)
+    fee: uint256
+    admin_fee: uint256
+    offpeg_fee_multiplier: uint256
+
+event NewFee:
+    fee: uint256
+    admin_fee: uint256
+    offpeg_fee_multiplier: uint256
+
+event RampA:
+    old_A: uint256
+    new_A: uint256
+    initial_time: uint256
+    future_time: uint256
+
+event StopRampA:
+    A: uint256
+    t: uint256
+
+
+# These constants must be set prior to compiling
+N_COINS: constant(int128) = 2
+PRECISION_MUL: constant(uint256[N_COINS]) = [1,1]
+
+# fixed constants
+FEE_DENOMINATOR: constant(uint256) = 10 ** 10
+PRECISION: constant(uint256) = 10 ** 18  # The precision to convert to
+
+MAX_ADMIN_FEE: constant(uint256) = 10 * 10 ** 9
+MAX_FEE: constant(uint256) = 5 * 10 ** 9
+
+MAX_A: constant(uint256) = 10 ** 6
+MAX_A_CHANGE: constant(uint256) = 10
+A_PRECISION: constant(uint256) = 100
+
+ADMIN_ACTIONS_DELAY: constant(uint256) = 3 * 86400
+MIN_RAMP_TIME: constant(uint256) = 86400
+
+coins: public(address[N_COINS])
+underlying_coins: public(address[N_COINS])
+admin_balances: public(uint256[N_COINS])
+
+fee: public(uint256)  # fee * 1e10
+offpeg_fee_multiplier: public(uint256)  # * 1e10
+admin_fee: public(uint256)  # admin_fee * 1e10
+
+owner: public(address)
+lp_token: public(address)
+
+# This may need to be changed for non-aave pools! 
+aave_lending_pool: address
+aave_referral: uint256
+
+initial_A: public(uint256)
+future_A: public(uint256)
+initial_A_time: public(uint256)
+future_A_time: public(uint256)
+
+admin_actions_deadline: public(uint256)
+transfer_ownership_deadline: public(uint256)
+future_fee: public(uint256)
+future_admin_fee: public(uint256)
+future_offpeg_fee_multiplier: public(uint256)  # * 1e10
+future_owner: public(address)
+
+is_killed: bool
+kill_deadline: uint256
+KILL_DEADLINE_DT: constant(uint256) = 2 * 30 * 86400
+
+
+@external
+def __init__(
+    _coins: address[N_COINS],
+    _underlying_coins: address[N_COINS],
+    _pool_token: address,
+    _aave_lending_pool: address,
+    _A: uint256,
+    _fee: uint256,
+    _admin_fee: uint256,
+    _offpeg_fee_multiplier: uint256,
+):
+    """
+    @notice Contract constructor
+    @param _coins List of wrapped coin addresses
+    @param _underlying_coins List of underlying coin addresses
+    @param _pool_token Pool LP token address
+    @param _aave_lending_pool Aave lending pool address
+    @param _A Amplification coefficient multiplied by n * (n - 1)
+    @param _fee Swap fee expressed as an integer with 1e10 precision
+    @param _admin_fee Percentage of fee taken as an admin fee,
+                      expressed as an integer with 1e10 precision
+    @param _offpeg_fee_multiplier Offpeg fee multiplier
+    """
+    for i in range(N_COINS):
+        assert _coins[i] != ZERO_ADDRESS
+        assert _underlying_coins[i] != ZERO_ADDRESS
+
+    self.coins = _coins
+    self.underlying_coins = _underlying_coins
+    self.initial_A = _A * A_PRECISION
+    self.future_A = _A * A_PRECISION
+    self.fee = _fee
+    self.admin_fee = _admin_fee
+    self.offpeg_fee_multiplier = _offpeg_fee_multiplier
+    self.owner = msg.sender
+    self.kill_deadline = block.timestamp + KILL_DEADLINE_DT
+    self.lp_token = _pool_token
+    self.aave_lending_pool = _aave_lending_pool
+
+    # approve transfer of underlying coin to aave lending pool
+    for coin in _underlying_coins:
+        _response: Bytes[32] = raw_call(
+            coin,
+            concat(
+                method_id("approve(address,uint256)"),
+                convert(_aave_lending_pool, bytes32),
+                convert(MAX_UINT256, bytes32)
+            ),
+            max_outsize=32
+        )
+        if len(_response) != 0:
+            assert convert(_response, bool)
+
+
+
+@view
+@internal
+def _A() -> uint256:
+    t1: uint256 = self.future_A_time
+    A1: uint256 = self.future_A
+
+    if block.timestamp < t1:
+        # handle ramping up and down of A
+        A0: uint256 = self.initial_A
+        t0: uint256 = self.initial_A_time
+        # Expressions in uint256 cannot have negative numbers, thus "if"
+        if A1 > A0:
+            return A0 + (A1 - A0) * (block.timestamp - t0) / (t1 - t0)
+        else:
+            return A0 - (A0 - A1) * (block.timestamp - t0) / (t1 - t0)
+
+    else:  # when t1 == 0 or block.timestamp >= t1
+        return A1
+
+
+@view
+@external
+def A() -> uint256:
+    return self._A() / A_PRECISION
+
+
+@view
+@external
+def A_precise() -> uint256:
+    return self._A()
+
+
+@pure
+@internal
+def _dynamic_fee(_xpi: uint256, _xpj: uint256, _fee: uint256, _feemul: uint256) -> uint256:
+    if _feemul <= FEE_DENOMINATOR:
+        return _fee
+    else:
+        xps2: uint256 = (_xpi + _xpj)
+        xps2 *= xps2  # Doing just ** 2 can overflow apparently
+        return (_feemul * _fee) / (
+            (_feemul - FEE_DENOMINATOR) * 4 * _xpi * _xpj / xps2 + \
+            FEE_DENOMINATOR)
+
+
+@view
+@external
+def dynamic_fee(i: int128, j: int128) -> uint256:
+    """
+    @notice Return the fee for swapping between `i` and `j`
+    @param i Index value for the coin to send
+    @param j Index value of the coin to recieve
+    @return Swap fee expressed as an integer with 1e10 precision
+    """
+    precisions: uint256[N_COINS] = PRECISION_MUL
+    xpi: uint256 = (ERC20(self.coins[i]).balanceOf(self) - self.admin_balances[i]) * precisions[i]
+    xpj: uint256 = (ERC20(self.coins[j]).balanceOf(self) - self.admin_balances[j]) * precisions[j]
+    return self._dynamic_fee(xpi, xpj, self.fee, self.offpeg_fee_multiplier)
+
+
+@view
+@external
+def balances(i: uint256) -> uint256:
+    """
+    @notice Get the current balance of a coin within the
+            pool, less the accrued admin fees
+    @param i Index value for the coin to query balance of
+    @return Token balance
+    """
+    return ERC20(self.coins[i]).balanceOf(self) - self.admin_balances[i]
+
+
+@view
+@internal
+def _balances() -> uint256[N_COINS]:
+    result: uint256[N_COINS] = empty(uint256[N_COINS])
+    for i in range(N_COINS):
+        result[i] = ERC20(self.coins[i]).balanceOf(self) - self.admin_balances[i]
+    return result
+
+
+@pure
+@internal
+def _get_D(_xp: uint256[N_COINS], _amp: uint256) -> uint256:
+    """
+    D invariant calculation in non-overflowing integer operations
+    iteratively
+
+    A * sum(x_i) * n**n + D = A * D * n**n + D**(n+1) / (n**n * prod(x_i))
+
+    Converging solution:
+    D[j+1] = (A * n**n * sum(x_i) - D[j]**(n+1) / (n**n prod(x_i))) / (A * n**n - 1)
+    """
+    S: uint256 = 0
+
+    for _x in _xp:
+        S += _x
+    if S == 0:
+        return 0
+
+    Dprev: uint256 = 0
+    D: uint256 = S
+    Ann: uint256 = _amp * N_COINS
+    for _i in range(255):
+        D_P: uint256 = D
+        for _x in _xp:
+            D_P = D_P * D / (_x * N_COINS + 1)  # +1 is to prevent /0
+        Dprev = D
+        D = (Ann * S / A_PRECISION + D_P * N_COINS) * D / ((Ann - A_PRECISION) * D / A_PRECISION + (N_COINS + 1) * D_P)
+        # Equality with the precision of 1
+        if D > Dprev:
+            if D - Dprev <= 1:
+                return D
+        else:
+            if Dprev - D <= 1:
+                return D
+    # convergence typically occurs in 4 rounds or less, this should be unreachable!
+    # if it does happen the pool is borked and LPs can withdraw via `remove_liquidity`
+    raise
+
+
+
+@view
+@internal
+def _get_D_precisions(_coin_balances: uint256[N_COINS], _amp: uint256) -> uint256:
+    xp: uint256[N_COINS] = PRECISION_MUL
+    for i in range(N_COINS):
+        xp[i] *= _coin_balances[i]
+    return self._get_D(xp, _amp)
+
+
+@view
+@external
+def get_virtual_price() -> uint256:
+    """
+    @notice The current virtual price of the pool LP token
+    @dev Useful for calculating profits
+    @return LP token virtual price normalized to 1e18
+    """
+    D: uint256 = self._get_D_precisions(self._balances(), self._A())
+    # D is in the units similar to DAI (e.g. converted to precision 1e18)
+    # When balanced, D = n * x_u - total virtual value of the portfolio
+    token_supply: uint256 = ERC20(self.lp_token).totalSupply()
+    return D * PRECISION / token_supply
+
+
+@view
+@external
+def calc_token_amount(_amounts: uint256[N_COINS], _is_deposit: bool) -> uint256:
+    """
+    @notice Calculate addition or reduction in token supply from a deposit or withdrawal
+    @dev This calculation accounts for slippage, but not fees.
+         Needed to prevent front-running, not for precise calculations!
+    @param _amounts Amount of each coin being deposited
+    @param _is_deposit set True for deposits, False for withdrawals
+    @return Expected amount of LP tokens received
+    """
+    amp: uint256 = self._A()
+    coin_balances: uint256[N_COINS] = self._balances()
+    D0: uint256 = self._get_D_precisions(coin_balances, amp)
+    for i in range(N_COINS):
+        if _is_deposit:
+            coin_balances[i] += _amounts[i]
+        else:
+            coin_balances[i] -= _amounts[i]
+    D1: uint256 = self._get_D_precisions(coin_balances, amp)
+    token_amount: uint256 = ERC20(self.lp_token).totalSupply()
+    diff: uint256 = 0
+    if _is_deposit:
+        diff = D1 - D0
+    else:
+        diff = D0 - D1
+    return diff * token_amount / D0
+
+
+@external
+@nonreentrant('lock')
+def add_liquidity(_amounts: uint256[N_COINS], _min_mint_amount: uint256, _use_underlying: bool = False) -> uint256:
+    """
+    @notice Deposit coins into the pool
+    @param _amounts List of amounts of coins to deposit
+    @param _min_mint_amount Minimum amount of LP tokens to mint from the deposit
+    @param _use_underlying If True, deposit underlying assets instead of aTokens
+    @return Amount of LP tokens received by depositing
+    """
+    assert not self.is_killed  # dev: is killed
+
+    # Initial invariant
+    amp: uint256 = self._A()
+    old_balances: uint256[N_COINS] = self._balances()
+    lp_token: address = self.lp_token
+    token_supply: uint256 = ERC20(lp_token).totalSupply()
+    D0: uint256 = 0
+    if token_supply != 0:
+        D0 = self._get_D_precisions(old_balances, amp)
+
+    new_balances: uint256[N_COINS] = old_balances
+    for i in range(N_COINS):
+        if token_supply == 0:
+            assert _amounts[i] != 0  # dev: initial deposit requires all coins
+        new_balances[i] += _amounts[i]
+
+    # Invariant after change
+    D1: uint256 = self._get_D_precisions(new_balances, amp)
+    assert D1 > D0
+
+    # We need to recalculate the invariant accounting for fees
+    # to calculate fair user's share
+    fees: uint256[N_COINS] = empty(uint256[N_COINS])
+    mint_amount: uint256 = 0
+    if token_supply != 0:
+        # Only account for fees if we are not the first to deposit
+        ys: uint256 = (D0 + D1) / N_COINS
+        fee: uint256 = self.fee * N_COINS / (4 * (N_COINS - 1))
+        feemul: uint256 = self.offpeg_fee_multiplier
+        admin_fee: uint256 = self.admin_fee
+        difference: uint256 = 0
+        for i in range(N_COINS):
+            ideal_balance: uint256 = D1 * old_balances[i] / D0
+            new_balance: uint256 = new_balances[i]
+            if ideal_balance > new_balance:
+                difference = ideal_balance - new_balance
+            else:
+                difference = new_balance - ideal_balance
+            xs: uint256 = old_balances[i] + new_balance
+            fees[i] = self._dynamic_fee(xs, ys, fee, feemul) * difference / FEE_DENOMINATOR
+            if admin_fee != 0:
+                self.admin_balances[i] += fees[i] * admin_fee / FEE_DENOMINATOR
+            new_balances[i] = new_balance - fees[i]
+        D2: uint256 = self._get_D_precisions(new_balances, amp)
+        mint_amount = token_supply * (D2 - D0) / D0
+    else:
+        mint_amount = D1  # Take the dust if there was any
+
+    assert mint_amount >= _min_mint_amount, "Slippage screwed you"
+
+    # Take coins from the sender
+    if _use_underlying:
+        lending_pool: address = self.aave_lending_pool
+        # This may not be needed for non-aave pools
+        aave_referral: bytes32 = convert(self.aave_referral, bytes32)
+
+        # Take coins from the sender
+        for i in range(N_COINS):
+            amount: uint256 = _amounts[i]
+            if amount != 0:
+                coin: address = self.underlying_coins[i]
+                # transfer underlying coin from msg.sender to self
+                _response: Bytes[32] = raw_call(
+                    coin,
+                    concat(
+                        method_id("transferFrom(address,address,uint256)"),
+                        convert(msg.sender, bytes32),
+                        convert(self, bytes32),
+                        convert(amount, bytes32)
+                    ),
+                    max_outsize=32
+                )
+                if len(_response) != 0:
+                    assert convert(_response, bool)
+
+                # deposit to aave lending pool: this may need to be changed for non-aave pools!
+                raw_call(
+                    lending_pool,
+                    concat(
+                        method_id("deposit(address,uint256,address,uint16)"),
+                        convert(coin, bytes32),
+                        convert(amount, bytes32),
+                        convert(self, bytes32),
+                        aave_referral,
+                    )
+                )
+    else:
+        for i in range(N_COINS):
+            amount: uint256 = _amounts[i]
+            if amount != 0:
+                _response: Bytes[32] = raw_call(
+                    self.coins[i],
+                    concat(
+                        method_id("transferFrom(address,address,uint256)"),
+                        convert(msg.sender, bytes32),
+                        convert(self, bytes32),
+                        convert(amount, bytes32)
+                    ),
+                    max_outsize=32
+                ) # dev: failed transfer
+                if len(_response) != 0:
+                    assert convert(_response, bool)
+    # Mint pool tokens
+    CurveToken(lp_token).mint(msg.sender, mint_amount)
+
+    log AddLiquidity(msg.sender, _amounts, fees, D1, token_supply + mint_amount)
+
+    return mint_amount
+
+
+@view
+@internal
+def _get_y(i: int128, j: int128, x: uint256, _xp: uint256[N_COINS]) -> uint256:
+    """
+    Calculate x[j] if one makes x[i] = x
+
+    Done by solving quadratic equation iteratively.
+    x_1**2 + x_1 * (sum' - (A*n**n - 1) * D / (A * n**n)) = D ** (n + 1) / (n ** (2 * n) * prod' * A)
+    x_1**2 + b*x_1 = c
+
+    x_1 = (x_1**2 + c) / (2*x_1 + b)
+    """
+    # x in the input is converted to the same price/precision
+
+    assert i != j       # dev: same coin
+    assert j >= 0       # dev: j below zero
+    assert j < N_COINS  # dev: j above N_COINS
+
+    # should be unreachable, but good for safety
+    assert i >= 0
+    assert i < N_COINS
+
+    A: uint256 = self._A()
+    D: uint256 = self._get_D(_xp, A)
+    Ann: uint256 = A * N_COINS
+    c: uint256 = D
+    S: uint256 = 0
+    _x: uint256 = 0
+    y_prev: uint256 = 0
+
+    for _i in range(N_COINS):
+        if _i == i:
+            _x = x
+        elif _i != j:
+            _x = _xp[_i]
+        else:
+            continue
+        S += _x
+        c = c * D / (_x * N_COINS)
+    c = c * D * A_PRECISION / (Ann * N_COINS)
+    b: uint256 = S + D * A_PRECISION / Ann  # - D
+    y: uint256 = D
+    for _i in range(255):
+        y_prev = y
+        y = (y*y + c) / (2 * y + b - D)
+        # Equality with the precision of 1
+        if y > y_prev:
+            if y - y_prev <= 1:
+                return y
+        else:
+            if y_prev - y <= 1:
+                return y
+    raise
+
+
+@view
+@internal
+def _get_dy(i: int128, j: int128, _dx: uint256) -> uint256:
+    xp: uint256[N_COINS] = self._balances()
+    precisions: uint256[N_COINS] = PRECISION_MUL
+    for k in range(N_COINS):
+        xp[k] *= precisions[k]
+
+    x: uint256 = xp[i] + _dx * precisions[i]
+    y: uint256 = self._get_y(i, j, x, xp)
+    dy: uint256 = (xp[j] - y) / precisions[j]
+    fee: uint256 = self._dynamic_fee(
+            (xp[i] + x) / 2, (xp[j] + y) / 2, self.fee, self.offpeg_fee_multiplier
+        ) * dy / FEE_DENOMINATOR
+    return dy - fee
+
+
+@view
+@external
+def get_dy(i: int128, j: int128, _dx: uint256) -> uint256:
+    return self._get_dy(i, j, _dx)
+
+
+@view
+@external
+def get_dy_underlying(i: int128, j: int128, _dx: uint256) -> uint256:
+    return self._get_dy(i, j, _dx)
+
+
+@internal
+def _exchange(i: int128, j: int128, dx: uint256) -> uint256:
+    assert not self.is_killed  # dev: is killed
+    # dx and dy are in aTokens
+
+    xp: uint256[N_COINS] = self._balances()
+    precisions: uint256[N_COINS] = PRECISION_MUL
+    for k in range(N_COINS):
+        xp[k] *= precisions[k]
+
+    x: uint256 = xp[i] + dx * precisions[i]
+    y: uint256 = self._get_y(i, j, x, xp)
+    dy: uint256 = xp[j] - y
+    dy_fee: uint256 = dy * self._dynamic_fee(
+            (xp[i] + x) / 2, (xp[j] + y) / 2, self.fee, self.offpeg_fee_multiplier
+        ) / FEE_DENOMINATOR
+
+    admin_fee: uint256 = self.admin_fee
+    if admin_fee != 0:
+        dy_admin_fee: uint256 = dy_fee * admin_fee / FEE_DENOMINATOR
+        if dy_admin_fee != 0:
+            self.admin_balances[j] += dy_admin_fee / precisions[j]
+
+    return (dy - dy_fee) / precisions[j]
+
+
+@external
+@nonreentrant('lock')
+def exchange(i: int128, j: int128, _dx: uint256, _min_dy: uint256) -> uint256:
+    """
+    @notice Perform an exchange between two coins
+    @dev Index values can be found via the `coins` public getter method
+    @param i Index value for the coin to send
+    @param j Index valie of the coin to recieve
+    @param _dx Amount of `i` being exchanged
+    @param _min_dy Minimum amount of `j` to receive
+    @return Actual amount of `j` received
+    """
+    dy: uint256 = self._exchange(i, j, _dx)
+    assert dy >= _min_dy, "Exchange resulted in fewer coins than expected"
+
+    _response: Bytes[32] = raw_call(
+        self.coins[i],
+        concat(
+            method_id("transferFrom(address,address,uint256)"),
+            convert(msg.sender, bytes32),
+            convert(self, bytes32),
+            convert(_dx, bytes32)
+        ),
+        max_outsize=32
+    )
+    if len(_response) != 0:
+        assert convert(_response, bool)
+
+    _response = raw_call(
+        self.coins[j],
+        concat(
+            method_id("transfer(address,uint256)"),
+            convert(msg.sender, bytes32),
+            convert(dy, bytes32)
+        ),
+        max_outsize=32
+    )
+    if len(_response) != 0:
+        assert convert(_response, bool)
+
+    log TokenExchange(msg.sender, i, _dx, j, dy)
+
+    return dy
+
+
+@external
+@nonreentrant('lock')
+def exchange_underlying(i: int128, j: int128, _dx: uint256, _min_dy: uint256) -> uint256:
+    """
+    @notice Perform an exchange between two underlying coins
+    @dev Index values can be found via the `underlying_coins` public getter method
+    @param i Index value for the underlying coin to send
+    @param j Index valie of the underlying coin to recieve
+    @param _dx Amount of `i` being exchanged
+    @param _min_dy Minimum amount of `j` to receive
+    @return Actual amount of `j` received
+    """
+    dy: uint256 = self._exchange(i, j, _dx)
+    assert dy >= _min_dy, "Exchange resulted in fewer coins than expected"
+
+    u_coin_i: address = self.underlying_coins[i]
+    lending_pool: address = self.aave_lending_pool
+
+    # transfer underlying coin from msg.sender to self
+    _response: Bytes[32] = raw_call(
+        u_coin_i,
+        concat(
+            method_id("transferFrom(address,address,uint256)"),
+            convert(msg.sender, bytes32),
+            convert(self, bytes32),
+            convert(_dx, bytes32)
+        ),
+        max_outsize=32
+    )
+    if len(_response) != 0:
+        assert convert(_response, bool)
+
+    # deposit to aave lending pool: this may need to be changed for non-aave pools!
+    raw_call(
+        lending_pool,
+        concat(
+            method_id("deposit(address,uint256,address,uint16)"),
+            convert(u_coin_i, bytes32),
+            convert(_dx, bytes32),
+            convert(self, bytes32),
+            convert(self.aave_referral, bytes32),
+        )
+    )
+    # withdraw `j` underlying from lending pool and transfer to caller
+    LendingPool(lending_pool).withdraw(self.underlying_coins[j], dy, msg.sender)
+
+    log TokenExchangeUnderlying(msg.sender, i, _dx, j, dy)
+
+    return dy
+
+
+@external
+@nonreentrant('lock')
+def remove_liquidity(
+    _amount: uint256,
+    _min_amounts: uint256[N_COINS],
+    _use_underlying: bool = False,
+) -> uint256[N_COINS]:
+    """
+    @notice Withdraw coins from the pool
+    @dev Withdrawal amounts are based on current deposit ratios
+    @param _amount Quantity of LP tokens to burn in the withdrawal
+    @param _min_amounts Minimum amounts of underlying coins to receive
+    @param _use_underlying If True, withdraw underlying assets instead of aTokens
+    @return List of amounts of coins that were withdrawn
+    """
+    amounts: uint256[N_COINS] = self._balances()
+    lp_token: address = self.lp_token
+    total_supply: uint256 = ERC20(lp_token).totalSupply()
+    CurveToken(lp_token).burnFrom(msg.sender, _amount)  # dev: insufficient funds
+
+    lending_pool: address = ZERO_ADDRESS
+    if _use_underlying:
+        lending_pool = self.aave_lending_pool
+
+    for i in range(N_COINS):
+        value: uint256 = amounts[i] * _amount / total_supply
+        assert value >= _min_amounts[i], "Withdrawal resulted in fewer coins than expected"
+        amounts[i] = value
+        if _use_underlying:
+            LendingPool(lending_pool).withdraw(self.underlying_coins[i], value, msg.sender)
+        else:
+            # "safeTransferFrom" which works for ERC20s which return bool or not
+            _response: Bytes[32] = raw_call(
+                self.coins[i],
+                concat(
+                    method_id("transfer(address,uint256)"),
+                    convert(msg.sender, bytes32),
+                    convert(value, bytes32),
+                ),
+                max_outsize=32,
+            )  # dev: failed transfer
+            if len(_response) > 0:
+                assert convert(_response, bool)  # dev: failed transfer
+            # end "safeTransferFrom"
+
+    log RemoveLiquidity(msg.sender, amounts, empty(uint256[N_COINS]), total_supply - _amount)
+
+    return amounts
+
+
+@external
+@nonreentrant('lock')
+def remove_liquidity_imbalance(
+    _amounts: uint256[N_COINS],
+    _max_burn_amount: uint256,
+    _use_underlying: bool = False
+) -> uint256:
+    """
+    @notice Withdraw coins from the pool in an imbalanced amount
+    @param _amounts List of amounts of underlying coins to withdraw
+    @param _max_burn_amount Maximum amount of LP token to burn in the withdrawal
+    @param _use_underlying If True, withdraw underlying assets instead of aTokens
+    @return Actual amount of the LP token burned in the withdrawal
+    """
+    assert not self.is_killed  # dev: is killed
+
+    amp: uint256 = self._A()
+    old_balances: uint256[N_COINS] = self._balances()
+    D0: uint256 = self._get_D_precisions(old_balances, amp)
+    new_balances: uint256[N_COINS] = old_balances
+    for i in range(N_COINS):
+        new_balances[i] -= _amounts[i]
+    D1: uint256 = self._get_D_precisions(new_balances, amp)
+    ys: uint256 = (D0 + D1) / N_COINS
+
+    lp_token: address = self.lp_token
+    token_supply: uint256 = ERC20(lp_token).totalSupply()
+    assert token_supply != 0  # dev: zero total supply
+
+    fee: uint256 = self.fee * N_COINS / (4 * (N_COINS - 1))
+    feemul: uint256 = self.offpeg_fee_multiplier
+    admin_fee: uint256 = self.admin_fee
+    fees: uint256[N_COINS] = empty(uint256[N_COINS])
+    for i in range(N_COINS):
+        ideal_balance: uint256 = D1 * old_balances[i] / D0
+        new_balance: uint256 = new_balances[i]
+        difference: uint256 = 0
+        if ideal_balance > new_balance:
+            difference = ideal_balance - new_balance
+        else:
+            difference = new_balance - ideal_balance
+        xs: uint256 = new_balance + old_balances[i]
+        fees[i] = self._dynamic_fee(xs, ys, fee, feemul) * difference / FEE_DENOMINATOR
+        if admin_fee != 0:
+            self.admin_balances[i] += fees[i] * admin_fee / FEE_DENOMINATOR
+        new_balances[i] -= fees[i]
+    D2: uint256 = self._get_D_precisions(new_balances, amp)
+
+    token_amount: uint256 = (D0 - D2) * token_supply / D0
+    assert token_amount != 0  # dev: zero tokens burned
+    assert token_amount <= _max_burn_amount, "Slippage screwed you"
+
+    CurveToken(lp_token).burnFrom(msg.sender, token_amount)  # dev: insufficient funds
+
+    lending_pool: address = ZERO_ADDRESS
+    if _use_underlying:
+        lending_pool = self.aave_lending_pool
+
+    for i in range(N_COINS):
+        amount: uint256 = _amounts[i]
+        if amount != 0:
+            if _use_underlying:
+                LendingPool(lending_pool).withdraw(self.underlying_coins[i], amount, msg.sender)
+            else:
+                _response: Bytes[32] = raw_call(
+                self.coins[i],
+                concat(
+                    method_id("transfer(address,uint256)"),
+                    convert(msg.sender, bytes32),
+                    convert(amount, bytes32)
+                ),
+                max_outsize=32
+                )
+                if len(_response) != 0:
+                    assert convert(_response, bool)
+
+    log RemoveLiquidityImbalance(msg.sender, _amounts, fees, D1, token_supply - token_amount)
+
+    return token_amount
+
+
+@pure
+@internal
+def _get_y_D(A: uint256, i: int128, _xp: uint256[N_COINS], D: uint256) -> uint256:
+    """
+    Calculate x[i] if one reduces D from being calculated for xp to D
+
+    Done by solving quadratic equation iteratively.
+    x_1**2 + x_1 * (sum' - (A*n**n - 1) * D / (A * n**n)) = D ** (n + 1) / (n ** (2 * n) * prod' * A)
+    x_1**2 + b*x_1 = c
+
+    x_1 = (x_1**2 + c) / (2*x_1 + b)
+    """
+    # x in the input is converted to the same price/precision
+
+    assert i >= 0       # dev: i below zero
+    assert i < N_COINS  # dev: i above N_COINS
+
+    Ann: uint256 = A * N_COINS
+    c: uint256 = D
+    S_: uint256 = 0
+    _x: uint256 = 0
+    y_prev: uint256 = 0
+
+    for _i in range(N_COINS):
+        if _i != i:
+            _x = _xp[_i]
+        else:
+            continue
+        S_ += _x
+        c = c * D / (_x * N_COINS)
+    c = c * D * A_PRECISION / (Ann * N_COINS)
+    b: uint256 = S_ + D * A_PRECISION / Ann
+    y: uint256 = D
+
+    for _i in range(255):
+        y_prev = y
+        y = (y*y + c) / (2 * y + b - D)
+        # Equality with the precision of 1
+        if y > y_prev:
+            if y - y_prev <= 1:
+                return y
+        else:
+            if y_prev - y <= 1:
+                return y
+    raise
+
+
+@view
+@internal
+def _calc_withdraw_one_coin(_token_amount: uint256, i: int128) -> uint256:
+    # First, need to calculate
+    # * Get current D
+    # * Solve Eqn against y_i for D - _token_amount
+    amp: uint256 = self._A()
+    xp: uint256[N_COINS] = self._balances()
+    precisions: uint256[N_COINS] = PRECISION_MUL
+
+    for j in range(N_COINS):
+        xp[j] *= precisions[j]
+
+    D0: uint256 = self._get_D(xp, amp)
+    D1: uint256 = D0 - _token_amount * D0 / ERC20(self.lp_token).totalSupply()
+    new_y: uint256 = self._get_y_D(amp, i, xp, D1)
+
+    xp_reduced: uint256[N_COINS] = xp
+    ys: uint256 = (D0 + D1) / (2 * N_COINS)
+
+    fee: uint256 = self.fee * N_COINS / (4 * (N_COINS - 1))
+    feemul: uint256 = self.offpeg_fee_multiplier
+    for j in range(N_COINS):
+        dx_expected: uint256 = 0
+        xavg: uint256 = 0
+        if j == i:
+            dx_expected = xp[j] * D1 / D0 - new_y
+            xavg = (xp[j] + new_y) / 2
+        else:
+            dx_expected = xp[j] - xp[j] * D1 / D0
+            xavg = xp[j]
+        xp_reduced[j] -= self._dynamic_fee(xavg, ys, fee, feemul) * dx_expected / FEE_DENOMINATOR
+
+    dy: uint256 = xp_reduced[i] - self._get_y_D(amp, i, xp_reduced, D1)
+
+    return (dy - 1) / precisions[i]
+
+
+@view
+@external
+def calc_withdraw_one_coin(_token_amount: uint256, i: int128) -> uint256:
+    """
+    @notice Calculate the amount received when withdrawing a single coin
+    @dev Result is the same for underlying or wrapped asset withdrawals
+    @param _token_amount Amount of LP tokens to burn in the withdrawal
+    @param i Index value of the coin to withdraw
+    @return Amount of coin received
+    """
+    return self._calc_withdraw_one_coin(_token_amount, i)
+
+
+@external
+@nonreentrant('lock')
+def remove_liquidity_one_coin(
+    _token_amount: uint256,
+    i: int128,
+    _min_amount: uint256,
+    _use_underlying: bool = False
+) -> uint256:
+    """
+    @notice Withdraw a single coin from the pool
+    @param _token_amount Amount of LP tokens to burn in the withdrawal
+    @param i Index value of the coin to withdraw
+    @param _min_amount Minimum amount of coin to receive
+    @param _use_underlying If True, withdraw underlying assets instead of aTokens
+    @return Amount of coin received
+    """
+    assert not self.is_killed  # dev: is killed
+
+    dy: uint256 = self._calc_withdraw_one_coin(_token_amount, i)
+    assert dy >= _min_amount, "Not enough coins removed"
+
+    CurveToken(self.lp_token).burnFrom(msg.sender, _token_amount)  # dev: insufficient funds
+
+    if _use_underlying:
+        LendingPool(self.aave_lending_pool).withdraw(self.underlying_coins[i], dy, msg.sender)
+    else:
+        _response: Bytes[32] = raw_call(
+        self.coins[i],
+        concat(
+            method_id("transfer(address,uint256)"),
+            convert(msg.sender, bytes32),
+            convert(dy, bytes32)
+        ),
+        max_outsize=32
+        )
+        if len(_response) != 0:
+            assert convert(_response, bool)
+
+    log RemoveLiquidityOne(msg.sender, _token_amount, dy)
+
+    return dy
+
+
+### Admin functions ###
+
+@external
+def ramp_A(_future_A: uint256, _future_time: uint256):
+    assert msg.sender == self.owner  # dev: only owner
+    assert block.timestamp >= self.initial_A_time + MIN_RAMP_TIME
+    assert _future_time >= block.timestamp + MIN_RAMP_TIME  # dev: insufficient time
+
+    initial_A: uint256 = self._A()
+    future_A_p: uint256 = _future_A * A_PRECISION
+
+    assert _future_A > 0 and _future_A < MAX_A
+    if future_A_p < initial_A:
+        assert future_A_p * MAX_A_CHANGE >= initial_A
+    else:
+        assert future_A_p <= initial_A * MAX_A_CHANGE
+
+    self.initial_A = initial_A
+    self.future_A = future_A_p
+    self.initial_A_time = block.timestamp
+    self.future_A_time = _future_time
+
+    log RampA(initial_A, future_A_p, block.timestamp, _future_time)
+
+
+@external
+def stop_ramp_A():
+    assert msg.sender == self.owner  # dev: only owner
+
+    current_A: uint256 = self._A()
+    self.initial_A = current_A
+    self.future_A = current_A
+    self.initial_A_time = block.timestamp
+    self.future_A_time = block.timestamp
+    # now (block.timestamp < t1) is always False, so we return saved A
+
+    log StopRampA(current_A, block.timestamp)
+
+
+@external
+def commit_new_fee(_new_fee: uint256, _new_admin_fee: uint256, _new_offpeg_fee_multiplier: uint256):
+    assert msg.sender == self.owner  # dev: only owner
+    assert self.admin_actions_deadline == 0  # dev: active action
+    assert _new_fee <= MAX_FEE  # dev: fee exceeds maximum
+    assert _new_admin_fee <= MAX_ADMIN_FEE  # dev: admin fee exceeds maximum
+    assert _new_offpeg_fee_multiplier * _new_fee <= MAX_FEE * FEE_DENOMINATOR  # dev: offpeg multiplier exceeds maximum
+
+    deadline: uint256 = block.timestamp + ADMIN_ACTIONS_DELAY
+    self.admin_actions_deadline = deadline
+    self.future_fee = _new_fee
+    self.future_admin_fee = _new_admin_fee
+    self.future_offpeg_fee_multiplier = _new_offpeg_fee_multiplier
+
+    log CommitNewFee(deadline, _new_fee, _new_admin_fee, _new_offpeg_fee_multiplier)
+
+
+@external
+@nonreentrant('lock')
+def apply_new_fee():
+    assert msg.sender == self.owner  # dev: only owner
+    assert block.timestamp >= self.admin_actions_deadline  # dev: insufficient time
+    assert self.admin_actions_deadline != 0  # dev: no active action
+
+    self.admin_actions_deadline = 0
+    fee: uint256 = self.future_fee
+    admin_fee: uint256 = self.future_admin_fee
+    fml: uint256 = self.future_offpeg_fee_multiplier
+    self.fee = fee
+    self.admin_fee = admin_fee
+    self.offpeg_fee_multiplier = fml
+
+    log NewFee(fee, admin_fee, fml)
+
+
+@external
+def revert_new_parameters():
+    assert msg.sender == self.owner  # dev: only owner
+
+    self.admin_actions_deadline = 0
+
+
+@external
+def commit_transfer_ownership(_owner: address):
+    assert msg.sender == self.owner  # dev: only owner
+    assert self.transfer_ownership_deadline == 0  # dev: active transfer
+
+    deadline: uint256 = block.timestamp + ADMIN_ACTIONS_DELAY
+    self.transfer_ownership_deadline = deadline
+    self.future_owner = _owner
+
+    log CommitNewAdmin(deadline, _owner)
+
+
+@external
+@nonreentrant('lock')
+def apply_transfer_ownership():
+    assert msg.sender == self.owner  # dev: only owner
+    assert block.timestamp >= self.transfer_ownership_deadline  # dev: insufficient time
+    assert self.transfer_ownership_deadline != 0  # dev: no active transfer
+
+    self.transfer_ownership_deadline = 0
+    owner: address = self.future_owner
+    self.owner = owner
+
+    log NewAdmin(owner)
+
+
+@external
+def revert_transfer_ownership():
+    assert msg.sender == self.owner  # dev: only owner
+
+    self.transfer_ownership_deadline = 0
+
+
+@external
+@nonreentrant('lock')
+def withdraw_admin_fees():
+    assert msg.sender == self.owner  # dev: only owner
+
+    for i in range(N_COINS):
+        value: uint256 = self.admin_balances[i]
+        if value != 0:
+            # "safeTransferFrom" which works for ERC20s which return bool or not
+            _response: Bytes[32] = raw_call(
+                self.coins[i],
+                concat(
+                    method_id("transfer(address,uint256)"),
+                    convert(msg.sender, bytes32),
+                    convert(value, bytes32),
+                ),
+                max_outsize=32,
+            )  # dev: failed transfer
+            if len(_response) > 0:
+                assert convert(_response, bool)  # dev: failed transfer
+            # end "safeTransferFrom"
+            self.admin_balances[i] = 0
+
+
+@external
+def donate_admin_fees():
+    """
+    Just in case admin balances somehow become higher than total (rounding error?)
+    this can be used to fix the state, too
+    """
+    assert msg.sender == self.owner  # dev: only owner
+    self.admin_balances = empty(uint256[N_COINS])
+
+
+@external
+def kill_me():
+    assert msg.sender == self.owner  # dev: only owner
+    assert self.kill_deadline > block.timestamp  # dev: deadline has passed
+    self.is_killed = True
+
+
+@external
+def unkill_me():
+    assert msg.sender == self.owner  # dev: only owner
+    self.is_killed = False
+
+
+# This may not be required for non-aave pools
+@external
+def set_aave_referral(_referral_code: uint256):
+    assert msg.sender == self.owner  # dev: only owner
+    assert _referral_code < 2 ** 16  # dev: uint16 overflow
+    self.aave_referral = _referral_code

--- a/contracts/pool-templates/a/SwapTemplateA.vy
+++ b/contracts/pool-templates/a/SwapTemplateA.vy
@@ -92,8 +92,8 @@ event StopRampA:
 
 
 # These constants must be set prior to compiling
-N_COINS: constant(int128) = 2
-PRECISION_MUL: constant(uint256[N_COINS]) = [1,1]
+N_COINS: constant(int128) = ___N_COINS___
+PRECISION_MUL: constant(uint256[N_COINS]) = ___PRECISION_MUL___
 
 # fixed constants
 FEE_DENOMINATOR: constant(uint256) = 10 ** 10
@@ -385,14 +385,12 @@ def add_liquidity(_amounts: uint256[N_COINS], _min_mint_amount: uint256, _use_un
 
     amp: uint256 = self._A()
     old_balances: uint256[N_COINS] = self._balances()
-    lp_token: address = self.lp_token
-    token_supply: uint256 = CurveToken(lp_token).totalSupply()
     
     # Initial invariant
-    D0: uint256 = 0
-    if token_supply > 0:
-        D0 = self._get_D_precisions(old_balances, amp)
-
+    D0: uint256 = self._get_D_precisions(old_balances, amp)
+    
+    lp_token: address = self.lp_token
+    token_supply: uint256 = CurveToken(lp_token).totalSupply()
     new_balances: uint256[N_COINS] = old_balances
     for i in range(N_COINS):
         if token_supply == 0:
@@ -771,11 +769,6 @@ def remove_liquidity_imbalance(
         new_balances[i] -= _amounts[i]
     D1: uint256 = self._get_D_precisions(new_balances, amp)
     ys: uint256 = (D0 + D1) / N_COINS
-
-    lp_token: address = self.lp_token
-    token_supply: uint256 = CurveToken(lp_token).totalSupply()
-    assert token_supply != 0  # dev: zero total supply
-
     fee: uint256 = self.fee * N_COINS / (4 * (N_COINS - 1))
     feemul: uint256 = self.offpeg_fee_multiplier
     admin_fee: uint256 = self.admin_fee
@@ -795,6 +788,8 @@ def remove_liquidity_imbalance(
         new_balances[i] -= fees[i]
     D2: uint256 = self._get_D_precisions(new_balances, amp)
 
+    lp_token: address = self.lp_token
+    token_supply: uint256 = CurveToken(lp_token).totalSupply()
     token_amount: uint256 = (D0 - D2) * token_supply / D0
     assert token_amount != 0  # dev: zero tokens burned
     assert token_amount <= _max_burn_amount, "Slippage screwed you"

--- a/contracts/pool-templates/a/pooldata.json
+++ b/contracts/pool-templates/a/pooldata.json
@@ -1,0 +1,17 @@
+{
+  "wrapped_contract": "ATokenMock",
+  "coins": [
+    {
+      "decimals": 18,
+      "wrapped_decimals": 18,
+      "wrapped": true,
+      "tethered": false
+    },
+    {
+      "decimals": 18,
+      "wrapped_decimals": 18,
+      "wrapped": true,
+      "tethered": false
+    }
+  ]
+}

--- a/contracts/pool-templates/base/SwapTemplateBase.vy
+++ b/contracts/pool-templates/base/SwapTemplateBase.vy
@@ -303,14 +303,13 @@ def add_liquidity(_amounts: uint256[N_COINS], _min_mint_amount: uint256) -> uint
     assert not self.is_killed  # dev: is killed
 
     amp: uint256 = self._A()
-    lp_token: address = self.lp_token
-    token_supply: uint256 = CurveToken(lp_token).totalSupply()
+    old_balances: uint256[N_COINS] = self.balances
 
     # Initial invariant
-    D0: uint256 = 0
-    old_balances: uint256[N_COINS] = self.balances
-    if token_supply > 0:
-        D0 = self._get_D_mem(old_balances, amp)
+    D0: uint256 = self._get_D_mem(old_balances, amp)
+    
+    lp_token: address = self.lp_token
+    token_supply: uint256 = CurveToken(lp_token).totalSupply()
     new_balances: uint256[N_COINS] = old_balances
     for i in range(N_COINS):
         if token_supply == 0:
@@ -568,10 +567,6 @@ def remove_liquidity_imbalance(_amounts: uint256[N_COINS], _max_burn_amount: uin
         new_balances[i] -= _amounts[i]
     D1: uint256 = self._get_D_mem(new_balances, amp)
 
-    lp_token: address = self.lp_token
-    token_supply: uint256 = CurveToken(lp_token).totalSupply()
-    assert token_supply != 0  # dev: zero total supply
-
     fee: uint256 = self.fee * N_COINS / (4 * (N_COINS - 1))
     admin_fee: uint256 = self.admin_fee
     fees: uint256[N_COINS] = empty(uint256[N_COINS])
@@ -588,6 +583,8 @@ def remove_liquidity_imbalance(_amounts: uint256[N_COINS], _max_burn_amount: uin
         new_balances[i] = new_balance - fees[i]
     D2: uint256 = self._get_D_mem(new_balances, amp)
 
+    lp_token: address = self.lp_token
+    token_supply: uint256 = CurveToken(lp_token).totalSupply()
     token_amount: uint256 = (D0 - D2) * token_supply / D0
     assert token_amount != 0  # dev: zero tokens burned
     token_amount += 1  # In case of rounding errors - make it unfavorable for the "attacker"

--- a/contracts/pool-templates/eth/SwapTemplateEth.vy
+++ b/contracts/pool-templates/eth/SwapTemplateEth.vy
@@ -1,0 +1,889 @@
+# @version 0.2.8
+"""
+@title StableSwap
+@author Curve.Fi
+@license Copyright (c) Curve.Fi, 2020 - all rights reserved
+@notice Curve ETH pool implementation
+@dev This contract is only a template, pool-specific constants
+     must be set prior to compiling
+"""
+
+from vyper.interfaces import ERC20
+
+interface CurveToken:
+    def mint(_to: address, _value: uint256) -> bool: nonpayable
+    def burnFrom(_to: address, _value: uint256) -> bool: nonpayable
+
+
+# Events
+event TokenExchange:
+    buyer: indexed(address)
+    sold_id: int128
+    tokens_sold: uint256
+    bought_id: int128
+    tokens_bought: uint256
+
+event AddLiquidity:
+    provider: indexed(address)
+    token_amounts: uint256[N_COINS]
+    fees: uint256[N_COINS]
+    invariant: uint256
+    token_supply: uint256
+
+event RemoveLiquidity:
+    provider: indexed(address)
+    token_amounts: uint256[N_COINS]
+    fees: uint256[N_COINS]
+    token_supply: uint256
+
+event RemoveLiquidityOne:
+    provider: indexed(address)
+    token_amount: uint256
+    coin_amount: uint256
+    token_supply: uint256
+
+event RemoveLiquidityImbalance:
+    provider: indexed(address)
+    token_amounts: uint256[N_COINS]
+    fees: uint256[N_COINS]
+    invariant: uint256
+    token_supply: uint256
+
+event CommitNewAdmin:
+    deadline: indexed(uint256)
+    admin: indexed(address)
+
+event NewAdmin:
+    admin: indexed(address)
+
+event CommitNewFee:
+    deadline: indexed(uint256)
+    fee: uint256
+    admin_fee: uint256
+
+event NewFee:
+    fee: uint256
+    admin_fee: uint256
+
+event RampA:
+    old_A: uint256
+    new_A: uint256
+    initial_time: uint256
+    future_time: uint256
+
+event StopRampA:
+    A: uint256
+    t: uint256
+
+
+# These constants must be set prior to compiling
+N_COINS: constant(int128) = ___N_COINS___
+
+# fixed constants
+FEE_DENOMINATOR: constant(uint256) = 10 ** 10
+PRECISION: constant(uint256) = 10 ** 18  # The precision to convert to
+
+MAX_ADMIN_FEE: constant(uint256) = 10 * 10 ** 9
+MAX_FEE: constant(uint256) = 5 * 10 ** 9
+MAX_A: constant(uint256) = 10 ** 6
+MAX_A_CHANGE: constant(uint256) = 10
+
+ADMIN_ACTIONS_DELAY: constant(uint256) = 3 * 86400
+MIN_RAMP_TIME: constant(uint256) = 86400
+
+coins: public(address[N_COINS])
+balances: public(uint256[N_COINS])
+fee: public(uint256)  # fee * 1e10
+admin_fee: public(uint256)  # admin_fee * 1e10
+
+owner: public(address)
+lp_token: public(address)
+
+A_PRECISION: constant(uint256) = 100
+initial_A: public(uint256)
+future_A: public(uint256)
+initial_A_time: public(uint256)
+future_A_time: public(uint256)
+
+admin_actions_deadline: public(uint256)
+transfer_ownership_deadline: public(uint256)
+future_fee: public(uint256)
+future_admin_fee: public(uint256)
+future_owner: public(address)
+
+is_killed: bool
+kill_deadline: uint256
+KILL_DEADLINE_DT: constant(uint256) = 2 * 30 * 86400
+
+
+@external
+def __init__(
+    _owner: address,
+    _coins: address[N_COINS],
+    _pool_token: address,
+    _A: uint256,
+    _fee: uint256,
+    _admin_fee: uint256
+):
+    """
+    @notice Contract constructor
+    @param _owner Contract owner address
+    @param _coins Addresses of ERC20 conracts of coins
+    @param _pool_token Address of the token representing LP share
+    @param _A Amplification coefficient multiplied by n * (n - 1)
+    @param _fee Fee to charge for exchanges
+    @param _admin_fee Admin fee
+    """
+    for i in range(N_COINS):
+        assert _coins[i] != ZERO_ADDRESS
+    self.coins = _coins
+    self.initial_A = _A * A_PRECISION
+    self.future_A = _A * A_PRECISION
+    self.fee = _fee
+    self.admin_fee = _admin_fee
+    self.owner = _owner
+    self.kill_deadline = block.timestamp + KILL_DEADLINE_DT
+    self.lp_token = _pool_token
+
+
+@view
+@internal
+def _A() -> uint256:
+    """
+    Handle ramping A up or down
+    """
+    t1: uint256 = self.future_A_time
+    A1: uint256 = self.future_A
+
+    if block.timestamp < t1:
+        A0: uint256 = self.initial_A
+        t0: uint256 = self.initial_A_time
+        # Expressions in uint256 cannot have negative numbers, thus "if"
+        if A1 > A0:
+            return A0 + (A1 - A0) * (block.timestamp - t0) / (t1 - t0)
+        else:
+            return A0 - (A0 - A1) * (block.timestamp - t0) / (t1 - t0)
+
+    else:  # when t1 == 0 or block.timestamp >= t1
+        return A1
+
+
+@view
+@external
+def A() -> uint256:
+    return self._A() / A_PRECISION
+
+
+@view
+@external
+def A_precise() -> uint256:
+    return self._A()
+
+
+@pure
+@internal
+def get_D(xp: uint256[N_COINS], amp: uint256) -> uint256:
+    S: uint256 = 0
+    Dprev: uint256 = 0
+    for _x in xp:
+        S += _x
+    if S == 0:
+        return 0
+
+    D: uint256 = S
+    Ann: uint256 = amp * N_COINS
+    for _i in range(255):
+        D_P: uint256 = D
+        for _x in xp:
+            D_P = D_P * D / (_x * N_COINS)  # If division by 0, this will be borked: only withdrawal will work. And that is good
+        Dprev = D
+        D = (Ann * S / A_PRECISION + D_P * N_COINS) * D / ((Ann - A_PRECISION) * D / A_PRECISION + (N_COINS + 1) * D_P)
+        # Equality with the precision of 1
+        if D > Dprev:
+            if D - Dprev <= 1:
+                return D
+        else:
+            if Dprev - D <= 1:
+                return D
+    # convergence typically occurs in 4 rounds or less, this should be unreachable!
+    # if it does happen the pool is borked and LPs can withdraw via `remove_liquidity`
+    raise
+
+
+@view
+@external
+def get_virtual_price() -> uint256:
+    """
+    @notice The current virtual price of the pool LP token
+    @dev Useful for calculating profits
+    @return LP token virtual price normalized to 1e18
+    """
+    D: uint256 = self.get_D(self.balances, self._A())
+    # D is in the units similar to DAI (e.g. converted to precision 1e18)
+    # When balanced, D = n * x_u - total virtual value of the portfolio
+    token_supply: uint256 = ERC20(self.lp_token).totalSupply()
+    return D * PRECISION / token_supply
+
+
+@view
+@external
+def calc_token_amount(_amounts: uint256[N_COINS], _is_deposit: bool) -> uint256:
+    """
+    @notice Calculate addition or reduction in token supply from a deposit or withdrawal
+    @dev This calculation accounts for slippage, but not fees.
+         Needed to prevent front-running, not for precise calculations!
+    @param _amounts Amount of each coin being deposited
+    @param _is_deposit set True for deposits, False for withdrawals
+    @return Expected amount of LP tokens received
+    """
+    amp: uint256 = self._A()
+    _balances: uint256[N_COINS] = self.balances
+    D0: uint256 = self.get_D(_balances, amp)
+    for i in range(N_COINS):
+        if _is_deposit:
+            _balances[i] += _amounts[i]
+        else:
+            _balances[i] -= _amounts[i]
+    D1: uint256 = self.get_D(_balances, amp)
+    token_amount: uint256 = ERC20(self.lp_token).totalSupply()
+    diff: uint256 = 0
+    if _is_deposit:
+        diff = D1 - D0
+    else:
+        diff = D0 - D1
+    return diff * token_amount / D0
+
+
+@payable
+@external
+@nonreentrant('lock')
+def add_liquidity(_amounts: uint256[N_COINS], _min_mint_amount: uint256) -> uint256:
+    """
+    @notice Deposit coins into the pool
+    @param _amounts List of amounts of coins to deposit
+    @param _min_mint_amount Minimum amount of LP tokens to mint from the deposit
+    @return Amount of LP tokens received by depositing
+    """
+    assert not self.is_killed  # dev: is killed
+
+    # Initial invariant
+    amp: uint256 = self._A()
+    old_balances: uint256[N_COINS] = self.balances
+    D0: uint256 = self.get_D(old_balances, amp)
+
+    lp_token: address = self.lp_token
+    token_supply: uint256 = ERC20(lp_token).totalSupply()
+    new_balances: uint256[N_COINS] = empty(uint256[N_COINS])
+    for i in range(N_COINS):
+        if token_supply == 0:
+            assert _amounts[i] > 0  # dev: initial deposit requires all coins
+        new_balances[i] = old_balances[i] + _amounts[i]
+
+    # Invariant after change
+    D1: uint256 = self.get_D(new_balances, amp)
+    assert D1 > D0
+
+    # We need to recalculate the invariant accounting for fees
+    # to calculate fair user's share
+    fees: uint256[N_COINS] = empty(uint256[N_COINS])
+    mint_amount: uint256 = 0
+    D2: uint256 = D1
+    if token_supply > 0:
+        # Only account for fees if we are not the first to deposit
+        fee: uint256 = self.fee * N_COINS / (4 * (N_COINS - 1))
+        admin_fee: uint256 = self.admin_fee
+        for i in range(N_COINS):
+            ideal_balance: uint256 = D1 * old_balances[i] / D0
+            difference: uint256 = 0
+            if ideal_balance > new_balances[i]:
+                difference = ideal_balance - new_balances[i]
+            else:
+                difference = new_balances[i] - ideal_balance
+            fees[i] = fee * difference / FEE_DENOMINATOR
+            self.balances[i] = new_balances[i] - (fees[i] * admin_fee / FEE_DENOMINATOR)
+            new_balances[i] -= fees[i]
+        D2 = self.get_D(new_balances, amp)
+        mint_amount = token_supply * (D2 - D0) / D0
+    else:
+        self.balances = new_balances
+        mint_amount = D1  # Take the dust if there was any
+
+    assert mint_amount >= _min_mint_amount, "Slippage screwed you"
+
+    # Take coins from the sender
+    for i in range(N_COINS):
+        coin: address = self.coins[i]
+        amount: uint256 = _amounts[i]
+        if coin == 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE:
+            assert msg.value == amount
+        elif amount > 0:
+            # "safeTransferFrom" which works for ERC20s which return bool or not
+            _response: Bytes[32] = raw_call(
+                coin,
+                concat(
+                    method_id("transferFrom(address,address,uint256)"),
+                    convert(msg.sender, bytes32),
+                    convert(self, bytes32),
+                    convert(amount, bytes32),
+                ),
+                max_outsize=32,
+            )  # dev: failed transfer
+            if len(_response) > 0:
+                assert convert(_response, bool)
+
+    # Mint pool tokens
+    CurveToken(lp_token).mint(msg.sender, mint_amount)
+
+    log AddLiquidity(msg.sender, _amounts, fees, D1, token_supply + mint_amount)
+
+    return mint_amount
+
+
+@view
+@internal
+def get_y(i: int128, j: int128, x: uint256, _xp: uint256[N_COINS]) -> uint256:
+    # x in the input is converted to the same price/precision
+
+    assert i != j       # dev: same coin
+    assert j >= 0       # dev: j below zero
+    assert j < N_COINS  # dev: j above N_COINS
+
+    # should be unreachable, but good for safety
+    assert i >= 0
+    assert i < N_COINS
+
+    A: uint256 = self._A()
+    D: uint256 = self.get_D(_xp, A)
+    c: uint256 = D
+    S: uint256 = 0
+    _x: uint256 = 0
+    y_prev: uint256 = 0
+    Ann: uint256 = A * N_COINS
+
+    for _i in range(N_COINS):
+        if _i == i:
+            _x = x
+        elif _i != j:
+            _x = _xp[_i]
+        else:
+            continue
+        S += _x
+        c = c * D / (_x * N_COINS)
+
+    c = c * D * A_PRECISION / (Ann * N_COINS)
+    b: uint256 = S + D * A_PRECISION / Ann  # - D
+    y: uint256 = D
+    for _i in range(255):
+        y_prev = y
+        y = (y*y + c) / (2 * y + b - D)
+        # Equality with the precision of 1
+        if y > y_prev:
+            if y - y_prev <= 1:
+                return y
+        else:
+            if y_prev - y <= 1:
+                return y
+    raise
+
+
+@view
+@external
+def get_dy(i: int128, j: int128, _dx: uint256) -> uint256:
+    xp: uint256[N_COINS] = self.balances
+    x: uint256 = xp[i] + _dx
+    y: uint256 = self.get_y(i, j, x, xp)
+    dy: uint256 = xp[j] - y - 1
+    fee: uint256 = self.fee * dy / FEE_DENOMINATOR
+    return dy - fee
+
+
+@payable
+@external
+@nonreentrant('lock')
+def exchange(i: int128, j: int128, _dx: uint256, _min_dy: uint256) -> uint256:
+    """
+    @notice Perform an exchange between two coins
+    @dev Index values can be found via the `coins` public getter method
+    @param i Index value for the coin to send
+    @param j Index valie of the coin to recieve
+    @param _dx Amount of `i` being exchanged
+    @param _min_dy Minimum amount of `j` to receive
+    @return Actual amount of `j` received
+    """
+    assert not self.is_killed  # dev: is killed
+
+    old_balances: uint256[N_COINS] = self.balances
+
+    x: uint256 = old_balances[i] + _dx
+    y: uint256 = self.get_y(i, j, x, old_balances)
+
+    dy: uint256 = old_balances[j] - y - 1  # -1 just in case there were some rounding errors
+    dy_fee: uint256 = dy * self.fee / FEE_DENOMINATOR
+
+    # Convert all to real units
+    dy = dy - dy_fee
+    assert dy >= _min_dy, "Exchange resulted in fewer coins than expected"
+
+    dy_admin_fee: uint256 = dy_fee * self.admin_fee / FEE_DENOMINATOR
+
+    # Change balances exactly in same way as we change actual ERC20 coin amounts
+    self.balances[i] = old_balances[i] + _dx
+    # When rounding errors happen, we undercharge admin fee in favor of LP
+    self.balances[j] = old_balances[j] - dy - dy_admin_fee
+
+    # "safeTransferFrom" which works for ERC20s which return bool or not
+    coin: address = self.coins[i]
+    if coin == 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE:
+        assert msg.value == _dx
+    else:
+        assert msg.value == 0
+        _response: Bytes[32] = raw_call(
+            coin,
+            concat(
+                method_id("transferFrom(address,address,uint256)"),
+                convert(msg.sender, bytes32),
+                convert(self, bytes32),
+                convert(_dx, bytes32),
+            ),
+            max_outsize=32,
+        )  # dev: failed transfer
+        if len(_response) > 0:
+            assert convert(_response, bool)
+
+    coin = self.coins[j]
+    if coin == 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE:
+        raw_call(msg.sender, b"", value=dy)
+    else:
+        _response: Bytes[32] = raw_call(
+            coin,
+            concat(
+                method_id("transfer(address,uint256)"),
+                convert(msg.sender, bytes32),
+                convert(dy, bytes32),
+            ),
+            max_outsize=32,
+        )  # dev: failed transfer
+        if len(_response) > 0:
+            assert convert(_response, bool)
+
+    log TokenExchange(msg.sender, i, _dx, j, dy)
+
+    return dy
+
+
+@external
+@nonreentrant('lock')
+def remove_liquidity(_amount: uint256, _min_amounts: uint256[N_COINS]) -> uint256[N_COINS]:
+    """
+    @notice Withdraw coins from the pool
+    @dev Withdrawal amounts are based on current deposit ratios
+    @param _amount Quantity of LP tokens to burn in the withdrawal
+    @param _min_amounts Minimum amounts of underlying coins to receive
+    @return List of amounts of coins that were withdrawn
+    """
+    lp_token: address = self.lp_token
+    total_supply: uint256 = ERC20(lp_token).totalSupply()
+    amounts: uint256[N_COINS] = empty(uint256[N_COINS])
+
+    CurveToken(lp_token).burnFrom(msg.sender, _amount)  # dev: insufficient funds
+
+    for i in range(N_COINS):
+        old_balance: uint256 = self.balances[i]
+        value: uint256 = old_balance * _amount / total_supply
+        assert value >= _min_amounts[i], "Withdrawal resulted in fewer coins than expected"
+
+        self.balances[i] = old_balance - value
+        amounts[i] = value
+        coin: address = self.coins[i]
+        if coin == 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE:
+            raw_call(msg.sender, b"", value=value)
+        else:
+            _response: Bytes[32] = raw_call(
+                coin,
+                concat(
+                    method_id("transfer(address,uint256)"),
+                    convert(msg.sender, bytes32),
+                    convert(value, bytes32),
+                ),
+                max_outsize=32,
+            )  # dev: failed transfer
+            if len(_response) > 0:
+                assert convert(_response, bool)
+
+    log RemoveLiquidity(msg.sender, amounts, empty(uint256[N_COINS]), total_supply - _amount)
+
+    return amounts
+
+
+@external
+@nonreentrant('lock')
+def remove_liquidity_imbalance(_amounts: uint256[N_COINS], _max_burn_amount: uint256) -> uint256:
+    """
+    @notice Withdraw coins from the pool in an imbalanced amount
+    @param _amounts List of amounts of underlying coins to withdraw
+    @param _max_burn_amount Maximum amount of LP token to burn in the withdrawal
+    @return Actual amount of the LP token burned in the withdrawal
+    """
+    assert not self.is_killed  # dev: is killed
+
+    amp: uint256 = self._A()
+    lp_token: address = self.lp_token
+    token_supply: uint256 = ERC20(lp_token).totalSupply()
+    assert token_supply != 0  # dev: zero total supply
+
+    old_balances: uint256[N_COINS] = self.balances
+    D0: uint256 = self.get_D(old_balances, amp)
+
+    new_balances: uint256[N_COINS] = empty(uint256[N_COINS])
+    for i in range(N_COINS):
+        new_balances[i] = old_balances[i] - _amounts[i]
+    D1: uint256 = self.get_D(new_balances, amp)
+
+    fees: uint256[N_COINS] = empty(uint256[N_COINS])
+    difference: uint256 = 0
+    fee: uint256 = self.fee * N_COINS / (4 * (N_COINS - 1))
+    admin_fee: uint256 = self.admin_fee
+    for i in range(N_COINS):
+        new_balance: uint256 = new_balances[i]
+        ideal_balance: uint256 = D1 * old_balances[i] / D0
+        if ideal_balance > new_balance:
+            difference = ideal_balance - new_balance
+        else:
+            difference = new_balance - ideal_balance
+        fees[i] = fee * difference / FEE_DENOMINATOR
+        self.balances[i] = new_balance - (fees[i] * admin_fee / FEE_DENOMINATOR)
+        new_balances[i] = new_balance - fees[i]
+    D2: uint256 = self.get_D(new_balances, amp)
+
+    token_amount: uint256 = (D0 - D2) * token_supply / D0
+    assert token_amount != 0  # dev: zero tokens burned
+    token_amount += 1  # In case of rounding errors - make it unfavorable for the "attacker"
+    assert token_amount <= _max_burn_amount, "Slippage screwed you"
+
+    CurveToken(lp_token).burnFrom(msg.sender, token_amount)  # dev: insufficient funds
+
+    for i in range(N_COINS):
+        amount: uint256 = _amounts[i]
+        if amount != 0:
+            coin: address = self.coins[i]
+            if coin == 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE:
+                raw_call(msg.sender, b"", value=amount)
+            else:
+                _response: Bytes[32] = raw_call(
+                    coin,
+                    concat(
+                        method_id("transfer(address,uint256)"),
+                        convert(msg.sender, bytes32),
+                        convert(amount, bytes32),
+                    ),
+                    max_outsize=32,
+                )  # dev: failed transfer
+                if len(_response) > 0:
+                    assert convert(_response, bool)
+
+    log RemoveLiquidityImbalance(msg.sender, _amounts, fees, D1, token_supply - token_amount)
+
+    return token_amount
+
+
+@view
+@internal
+def get_y_D(A: uint256, i: int128, _xp: uint256[N_COINS], D: uint256) -> uint256:
+    """
+    Calculate x[i] if one reduces D from being calculated for xp to D
+
+    Done by solving quadratic equation iteratively.
+    x_1**2 + x_1 * (sum' - (A*n**n - 1) * D / (A * n**n)) = D ** (n + 1) / (n ** (2 * n) * prod' * A)
+    x_1**2 + b*x_1 = c
+
+    x_1 = (x_1**2 + c) / (2*x_1 + b)
+    """
+    # x in the input is converted to the same price/precision
+
+    assert i >= 0  # dev: i below zero
+    assert i < N_COINS  # dev: i above N_COINS
+
+    S: uint256 = 0
+    _x: uint256 = 0
+    y_prev: uint256 = 0
+    c: uint256 = D
+    Ann: uint256 = A * N_COINS
+
+    for _i in range(N_COINS):
+        if _i != i:
+            _x = _xp[_i]
+        else:
+            continue
+        S += _x
+        c = c * D / (_x * N_COINS)
+    c = c * D * A_PRECISION / (Ann * N_COINS)
+    b: uint256 = S + D * A_PRECISION / Ann
+
+    y: uint256 = D
+    for _i in range(255):
+        y_prev = y
+        y = (y*y + c) / (2 * y + b - D)
+        # Equality with the precision of 1
+        if y > y_prev:
+            if y - y_prev <= 1:
+                return y
+        else:
+            if y_prev - y <= 1:
+                return y
+    raise
+
+
+@view
+@internal
+def _calc_withdraw_one_coin(_token_amount: uint256, i: int128) -> (uint256, uint256, uint256):
+    # First, need to calculate
+    # * Get current D
+    # * Solve Eqn against y_i for D - _token_amount
+    amp: uint256 = self._A()
+    xp: uint256[N_COINS] = self.balances
+    D0: uint256 = self.get_D(xp, amp)
+    total_supply: uint256 = ERC20(self.lp_token).totalSupply()
+    D1: uint256 = D0 - _token_amount * D0 / total_supply
+    new_y: uint256 = self.get_y_D(amp, i, xp, D1)
+
+    fee: uint256 = self.fee * N_COINS / (4 * (N_COINS - 1))
+    xp_reduced: uint256[N_COINS] = xp
+    for j in range(N_COINS):
+        dx_expected: uint256 = 0
+        if j == i:
+            dx_expected = xp[j] * D1 / D0 - new_y
+        else:
+            dx_expected = xp[j] - xp[j] * D1 / D0
+        xp_reduced[j] -= fee * dx_expected / FEE_DENOMINATOR
+
+    dy: uint256 = xp_reduced[i] - self.get_y_D(amp, i, xp_reduced, D1)
+
+    dy -= 1  # Withdraw less to account for rounding errors
+    dy_0: uint256 = xp[i] - new_y  # w/o fees
+
+    return dy, dy_0 - dy, total_supply
+
+
+@view
+@external
+def calc_withdraw_one_coin(_token_amount: uint256, i: int128) -> uint256:
+    """
+    @notice Calculate the amount received when withdrawing a single coin
+    @param _token_amount Amount of LP tokens to burn in the withdrawal
+    @param i Index value of the coin to withdraw
+    @return Amount of coin received
+    """
+    return self._calc_withdraw_one_coin(_token_amount, i)[0]
+
+
+@external
+@nonreentrant('lock')
+def remove_liquidity_one_coin(_token_amount: uint256, i: int128, _min_amount: uint256) -> uint256:
+    """
+    @notice Withdraw a single coin from the pool
+    @param _token_amount Amount of LP tokens to burn in the withdrawal
+    @param i Index value of the coin to withdraw
+    @param _min_amount Minimum amount of coin to receive
+    @return Amount of coin received
+    """
+    assert not self.is_killed  # dev: is killed
+
+    dy: uint256 = 0
+    dy_fee: uint256 = 0
+    total_supply: uint256 = 0
+    dy, dy_fee, total_supply = self._calc_withdraw_one_coin(_token_amount, i)
+    assert dy >= _min_amount, "Not enough coins removed"
+
+    self.balances[i] -= (dy + dy_fee * self.admin_fee / FEE_DENOMINATOR)
+    CurveToken(self.lp_token).burnFrom(msg.sender, _token_amount)  # dev: insufficient funds
+
+    coin: address = self.coins[i]
+    if coin == 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE:
+        raw_call(msg.sender, b"", value=dy)
+    else:
+        _response: Bytes[32] = raw_call(
+            coin,
+            concat(
+                method_id("transfer(address,uint256)"),
+                convert(msg.sender, bytes32),
+                convert(dy, bytes32),
+            ),
+            max_outsize=32,
+        )  # dev: failed transfer
+        if len(_response) > 0:
+            assert convert(_response, bool)
+
+    log RemoveLiquidityOne(msg.sender, _token_amount, dy, total_supply - _token_amount)
+
+    return dy
+
+
+### Admin functions ###
+@external
+def ramp_A(_future_A: uint256, _future_time: uint256):
+    assert msg.sender == self.owner  # dev: only owner
+    assert block.timestamp >= self.initial_A_time + MIN_RAMP_TIME
+    assert _future_time >= block.timestamp + MIN_RAMP_TIME  # dev: insufficient time
+
+    initial_A: uint256 = self._A()
+    future_A_p: uint256 = _future_A * A_PRECISION
+
+    assert _future_A > 0 and _future_A < MAX_A
+    if future_A_p < initial_A:
+        assert future_A_p * MAX_A_CHANGE >= initial_A
+    else:
+        assert future_A_p <= initial_A * MAX_A_CHANGE
+
+    self.initial_A = initial_A
+    self.future_A = future_A_p
+    self.initial_A_time = block.timestamp
+    self.future_A_time = _future_time
+
+    log RampA(initial_A, future_A_p, block.timestamp, _future_time)
+
+
+@external
+def stop_ramp_A():
+    assert msg.sender == self.owner  # dev: only owner
+
+    current_A: uint256 = self._A()
+    self.initial_A = current_A
+    self.future_A = current_A
+    self.initial_A_time = block.timestamp
+    self.future_A_time = block.timestamp
+    # now (block.timestamp < t1) is always False, so we return saved A
+
+    log StopRampA(current_A, block.timestamp)
+
+
+@external
+def commit_new_fee(_new_fee: uint256, _new_admin_fee: uint256):
+    assert msg.sender == self.owner  # dev: only owner
+    assert self.admin_actions_deadline == 0  # dev: active action
+    assert _new_fee <= MAX_FEE  # dev: fee exceeds maximum
+    assert _new_admin_fee <= MAX_ADMIN_FEE  # dev: admin fee exceeds maximum
+
+    deadline: uint256 = block.timestamp + ADMIN_ACTIONS_DELAY
+    self.admin_actions_deadline = deadline
+    self.future_fee = _new_fee
+    self.future_admin_fee = _new_admin_fee
+
+    log CommitNewFee(deadline, _new_fee, _new_admin_fee)
+
+
+@external
+@nonreentrant('lock')
+def apply_new_fee():
+    assert msg.sender == self.owner  # dev: only owner
+    assert block.timestamp >= self.admin_actions_deadline  # dev: insufficient time
+    assert self.admin_actions_deadline != 0  # dev: no active action
+
+    self.admin_actions_deadline = 0
+    fee: uint256 = self.future_fee
+    admin_fee: uint256 = self.future_admin_fee
+    self.fee = fee
+    self.admin_fee = admin_fee
+
+    log NewFee(fee, admin_fee)
+
+
+@external
+def revert_new_parameters():
+    assert msg.sender == self.owner  # dev: only owner
+
+    self.admin_actions_deadline = 0
+
+
+@external
+def commit_transfer_ownership(_owner: address):
+    assert msg.sender == self.owner  # dev: only owner
+    assert self.transfer_ownership_deadline == 0  # dev: active transfer
+
+    deadline: uint256 = block.timestamp + ADMIN_ACTIONS_DELAY
+    self.transfer_ownership_deadline = deadline
+    self.future_owner = _owner
+
+    log CommitNewAdmin(deadline, _owner)
+
+
+@external
+@nonreentrant('lock')
+def apply_transfer_ownership():
+    assert msg.sender == self.owner  # dev: only owner
+    assert block.timestamp >= self.transfer_ownership_deadline  # dev: insufficient time
+    assert self.transfer_ownership_deadline != 0  # dev: no active transfer
+
+    self.transfer_ownership_deadline = 0
+    owner: address = self.future_owner
+    self.owner = owner
+
+    log NewAdmin(owner)
+
+
+@external
+def revert_transfer_ownership():
+    assert msg.sender == self.owner  # dev: only owner
+
+    self.transfer_ownership_deadline = 0
+
+
+@view
+@external
+def admin_balances(i: uint256) -> uint256:
+    coin: address = self.coins[i]
+    if coin == 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE:
+        return self.balance - self.balances[i]
+    else:
+        return ERC20(coin).balanceOf(self) - self.balances[i]
+
+
+@external
+@nonreentrant('lock')
+def withdraw_admin_fees():
+    assert msg.sender == self.owner  # dev: only owner
+
+    for i in range(N_COINS):
+        coin: address = self.coins[i]
+        if coin == 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE:
+            value: uint256 = self.balance - self.balances[i]
+            if value > 0:
+                raw_call(msg.sender, b"", value=value)
+        else:
+            value: uint256 = ERC20(coin).balanceOf(self) - self.balances[i]
+            if value > 0:
+                _response: Bytes[32] = raw_call(
+                    coin,
+                    concat(
+                        method_id("transfer(address,uint256)"),
+                        convert(msg.sender, bytes32),
+                        convert(value, bytes32),
+                    ),
+                    max_outsize=32,
+                )  # dev: failed transfer
+                if len(_response) > 0:
+                    assert convert(_response, bool)
+
+
+@external
+@nonreentrant('lock')
+def donate_admin_fees():
+    assert msg.sender == self.owner  # dev: only owner
+    for i in range(N_COINS):
+        coin: address = self.coins[i]
+        if coin == 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE:
+            self.balances[i] = self.balance
+        else:
+            self.balances[i] = ERC20(coin).balanceOf(self)
+
+
+@external
+def kill_me():
+    assert msg.sender == self.owner  # dev: only owner
+    assert self.kill_deadline > block.timestamp  # dev: deadline has passed
+    self.is_killed = True
+
+
+@external
+def unkill_me():
+    assert msg.sender == self.owner  # dev: only owner
+    self.is_killed = False

--- a/contracts/pool-templates/eth/SwapTemplateEth.vy
+++ b/contracts/pool-templates/eth/SwapTemplateEth.vy
@@ -556,10 +556,6 @@ def remove_liquidity_imbalance(_amounts: uint256[N_COINS], _max_burn_amount: uin
         new_balances[i] = old_balances[i] - _amounts[i]
     D1: uint256 = self._get_D(new_balances, amp)
 
-    lp_token: address = self.lp_token
-    token_supply: uint256 = CurveToken(lp_token).totalSupply()
-    assert token_supply != 0  # dev: zero total supply
-
     fees: uint256[N_COINS] = empty(uint256[N_COINS])
     fee: uint256 = self.fee * N_COINS / (4 * (N_COINS - 1))
     admin_fee: uint256 = self.admin_fee
@@ -576,6 +572,8 @@ def remove_liquidity_imbalance(_amounts: uint256[N_COINS], _max_burn_amount: uin
         new_balances[i] = new_balance - fees[i]
     D2: uint256 = self._get_D(new_balances, amp)
 
+    lp_token: address = self.lp_token
+    token_supply: uint256 = CurveToken(lp_token).totalSupply()
     token_amount: uint256 = (D0 - D2) * token_supply / D0
     assert token_amount != 0  # dev: zero tokens burned
     token_amount += 1  # In case of rounding errors - make it unfavorable for the "attacker"

--- a/contracts/pool-templates/eth/pooldata.json
+++ b/contracts/pool-templates/eth/pooldata.json
@@ -1,0 +1,15 @@
+{
+  "base_pool_contract": "SwapTemplateEth",
+  "coins": [
+    {
+      "decimals": 18,
+      "tethered": false,
+      "wrapped": false
+    },
+    {
+      "decimals": 18,
+      "tethered": false,
+      "wrapped": false
+    }
+  ]
+}

--- a/contracts/pool-templates/eth/pooldata.json
+++ b/contracts/pool-templates/eth/pooldata.json
@@ -1,15 +1,18 @@
 {
-  "base_pool_contract": "SwapTemplateEth",
   "coins": [
     {
       "decimals": 18,
       "tethered": false,
-      "wrapped": false
+      "wrapped": false,
+      "underlying_address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
     },
     {
       "decimals": 18,
       "tethered": false,
       "wrapped": false
     }
-  ]
+  ],
+  "testing": {
+    "initial_amount": 10000
+  }
 }

--- a/contracts/pool-templates/meta/DepositTemplateMeta.vy
+++ b/contracts/pool-templates/meta/DepositTemplateMeta.vy
@@ -1,4 +1,4 @@
-# @version ^0.2.5
+# @version ^0.2.8
 """
 @title "Zap" Depositer for metapool
 @author Curve.Fi
@@ -61,8 +61,8 @@ def __init__(_pool: address, _token: address):
     """
     self.pool = _pool
     self.token = _token
-    _base_pool: address = CurveMeta(_pool).base_pool()
-    self.base_pool = _base_pool
+    base_pool: address = CurveMeta(_pool).base_pool()
+    self.base_pool = base_pool
 
     for i in range(N_COINS):
         coin: address = CurveMeta(_pool).coins(convert(i, uint256))
@@ -81,14 +81,14 @@ def __init__(_pool: address, _token: address):
             assert convert(_response, bool)
 
     for i in range(BASE_N_COINS):
-        coin: address = CurveBase(_base_pool).coins(i)
+        coin: address = CurveBase(base_pool).coins(i)
         self.base_coins[i] = coin
         # approve underlying coins for infinite transfers
         _response: Bytes[32] = raw_call(
             coin,
             concat(
                 method_id("approve(address,uint256)"),
-                convert(_base_pool, bytes32),
+                convert(base_pool, bytes32),
                 convert(MAX_UINT256, bytes32),
             ),
             max_outsize=32,
@@ -98,11 +98,11 @@ def __init__(_pool: address, _token: address):
 
 
 @external
-def add_liquidity(amounts: uint256[N_ALL_COINS], min_mint_amount: uint256) -> uint256:
+def add_liquidity(_amounts: uint256[N_ALL_COINS], _min_mint_amount: uint256) -> uint256:
     """
     @notice Wrap underlying coins and deposit them in the pool
-    @param amounts List of amounts of underlying coins to deposit
-    @param min_mint_amount Minimum amount of LP tokens to mint from the deposit
+    @param _amounts List of amounts of underlying coins to deposit
+    @param _min_mint_amount Minimum amount of LP tokens to mint from the deposit
     @return Amount of LP tokens received by depositing
     """
     meta_amounts: uint256[N_COINS] = empty(uint256[N_COINS])
@@ -111,7 +111,7 @@ def add_liquidity(amounts: uint256[N_ALL_COINS], min_mint_amount: uint256) -> ui
 
     # Transfer all coins in
     for i in range(N_ALL_COINS):
-        amount: uint256 = amounts[i]
+        amount: uint256 = _amounts[i]
         if amount == 0:
             continue
         coin: address = ZERO_ADDRESS
@@ -151,23 +151,23 @@ def add_liquidity(amounts: uint256[N_ALL_COINS], min_mint_amount: uint256) -> ui
         meta_amounts[MAX_COIN] = ERC20(self.coins[MAX_COIN]).balanceOf(self)
 
     # Deposit to the meta pool
-    CurveMeta(self.pool).add_liquidity(meta_amounts, min_mint_amount)
+    CurveMeta(self.pool).add_liquidity(meta_amounts, _min_mint_amount)
 
     # Transfer meta token back
-    _lp_token: address = self.token
-    _lp_amount: uint256 = ERC20(_lp_token).balanceOf(self)
-    assert ERC20(_lp_token).transfer(msg.sender, _lp_amount)
+    lp_token: address = self.token
+    lp_amount: uint256 = ERC20(lp_token).balanceOf(self)
+    assert ERC20(lp_token).transfer(msg.sender, lp_amount)
 
-    return _lp_amount
+    return lp_amount
 
 
 @external
-def remove_liquidity(_amount: uint256, min_amounts: uint256[N_ALL_COINS]) -> uint256[N_ALL_COINS]:
+def remove_liquidity(_amount: uint256, _min_amounts: uint256[N_ALL_COINS]) -> uint256[N_ALL_COINS]:
     """
     @notice Withdraw and unwrap coins from the pool
     @dev Withdrawal amounts are based on current deposit ratios
     @param _amount Quantity of LP tokens to burn in the withdrawal
-    @param min_amounts Minimum amounts of underlying coins to receive
+    @param _min_amounts Minimum amounts of underlying coins to receive
     @return List of amounts of underlying coins that were withdrawn
     """
     _token: address = self.token
@@ -179,13 +179,13 @@ def remove_liquidity(_amount: uint256, min_amounts: uint256[N_ALL_COINS]) -> uin
 
     # Withdraw from meta
     for i in range(MAX_COIN):
-        min_amounts_meta[i] = min_amounts[i]
+        min_amounts_meta[i] = _min_amounts[i]
     CurveMeta(self.pool).remove_liquidity(_amount, min_amounts_meta)
 
     # Withdraw from base
     _base_amount: uint256 = ERC20(self.coins[MAX_COIN]).balanceOf(self)
     for i in range(BASE_N_COINS):
-        min_amounts_base[i] = min_amounts[MAX_COIN+i]
+        min_amounts_base[i] = _min_amounts[MAX_COIN+i]
     CurveBase(self.base_pool).remove_liquidity(_base_amount, min_amounts_base)
 
     # Transfer all coins out
@@ -257,24 +257,24 @@ def remove_liquidity_one_coin(_token_amount: uint256, i: int128, _min_amount: ui
 
 
 @external
-def remove_liquidity_imbalance(amounts: uint256[N_ALL_COINS], max_burn_amount: uint256) -> uint256:
+def remove_liquidity_imbalance(_amounts: uint256[N_ALL_COINS], _max_burn_amount: uint256) -> uint256:
     """
     @notice Withdraw coins from the pool in an imbalanced amount
-    @param amounts List of amounts of underlying coins to withdraw
-    @param max_burn_amount Maximum amount of LP token to burn in the withdrawal
+    @param _amounts List of amounts of underlying coins to withdraw
+    @param _max_burn_amount Maximum amount of LP token to burn in the withdrawal
     @return Actual amount of the LP token burned in the withdrawal
     """
-    _base_pool: address = self.base_pool
-    _meta_pool: address = self.pool
-    _base_coins: address[BASE_N_COINS] = self.base_coins
-    _meta_coins: address[N_COINS] = self.coins
-    _lp_token: address = self.token
+    base_pool: address = self.base_pool
+    meta_pool: address = self.pool
+    base_coins: address[BASE_N_COINS] = self.base_coins
+    meta_coins: address[N_COINS] = self.coins
+    lp_token: address = self.token
 
-    fee: uint256 = CurveBase(_base_pool).fee() * BASE_N_COINS / (4 * (BASE_N_COINS - 1))
+    fee: uint256 = CurveBase(base_pool).fee() * BASE_N_COINS / (4 * (BASE_N_COINS - 1))
     fee += fee * FEE_IMPRECISION / FEE_DENOMINATOR  # Overcharge to account for imprecision
 
     # Transfer the LP token in
-    assert ERC20(_lp_token).transferFrom(msg.sender, self, max_burn_amount)
+    assert ERC20(lp_token).transferFrom(msg.sender, self, _max_burn_amount)
 
     withdraw_base: bool = False
     amounts_base: uint256[BASE_N_COINS] = empty(uint256[BASE_N_COINS])
@@ -283,10 +283,10 @@ def remove_liquidity_imbalance(amounts: uint256[N_ALL_COINS], max_burn_amount: u
 
     # Prepare quantities
     for i in range(MAX_COIN):
-        amounts_meta[i] = amounts[i]
+        amounts_meta[i] = _amounts[i]
 
     for i in range(BASE_N_COINS):
-        amount: uint256 = amounts[MAX_COIN + i]
+        amount: uint256 = _amounts[MAX_COIN + i]
         if amount != 0:
             amounts_base[i] = amount
             withdraw_base = True
@@ -296,22 +296,22 @@ def remove_liquidity_imbalance(amounts: uint256[N_ALL_COINS], max_burn_amount: u
         amounts_meta[MAX_COIN] += amounts_meta[MAX_COIN] * fee / FEE_DENOMINATOR + 1
 
     # Remove liquidity and deposit leftovers back
-    CurveMeta(_meta_pool).remove_liquidity_imbalance(amounts_meta, max_burn_amount)
+    CurveMeta(meta_pool).remove_liquidity_imbalance(amounts_meta, _max_burn_amount)
     if withdraw_base:
-        CurveBase(_base_pool).remove_liquidity_imbalance(amounts_base, amounts_meta[MAX_COIN])
-        leftover_amounts[MAX_COIN] = ERC20(_meta_coins[MAX_COIN]).balanceOf(self)
+        CurveBase(base_pool).remove_liquidity_imbalance(amounts_base, amounts_meta[MAX_COIN])
+        leftover_amounts[MAX_COIN] = ERC20(meta_coins[MAX_COIN]).balanceOf(self)
         if leftover_amounts[MAX_COIN] > 0:
-            CurveMeta(_meta_pool).add_liquidity(leftover_amounts, 0)
+            CurveMeta(meta_pool).add_liquidity(leftover_amounts, 0)
 
     # Transfer all coins out
     for i in range(N_ALL_COINS):
         coin: address = ZERO_ADDRESS
         amount: uint256 = 0
         if i < MAX_COIN:
-            coin = _meta_coins[i]
+            coin = meta_coins[i]
             amount = amounts_meta[i]
         else:
-            coin = _base_coins[i - MAX_COIN]
+            coin = base_coins[i - MAX_COIN]
             amount = amounts_base[i - MAX_COIN]
         # "safeTransfer" which works for ERC20s which return bool or not
         if amount > 0:
@@ -329,11 +329,11 @@ def remove_liquidity_imbalance(amounts: uint256[N_ALL_COINS], max_burn_amount: u
             # end "safeTransfer"
 
     # Transfer the leftover LP token out
-    leftover: uint256 = ERC20(_lp_token).balanceOf(self)
+    leftover: uint256 = ERC20(lp_token).balanceOf(self)
     if leftover > 0:
-        assert ERC20(_lp_token).transfer(msg.sender, leftover)
+        assert ERC20(lp_token).transfer(msg.sender, leftover)
 
-    return max_burn_amount - leftover
+    return _max_burn_amount - leftover
 
 
 @view
@@ -348,31 +348,31 @@ def calc_withdraw_one_coin(_token_amount: uint256, i: int128) -> uint256:
     if i < MAX_COIN:
         return CurveMeta(self.pool).calc_withdraw_one_coin(_token_amount, i)
     else:
-        _base_tokens: uint256 = CurveMeta(self.pool).calc_withdraw_one_coin(_token_amount, MAX_COIN)
-        return CurveBase(self.base_pool).calc_withdraw_one_coin(_base_tokens, i-MAX_COIN)
+        base_tokens: uint256 = CurveMeta(self.pool).calc_withdraw_one_coin(_token_amount, MAX_COIN)
+        return CurveBase(self.base_pool).calc_withdraw_one_coin(base_tokens, i-MAX_COIN)
 
 
 @view
 @external
-def calc_token_amount(amounts: uint256[N_ALL_COINS], is_deposit: bool) -> uint256:
+def calc_token_amount(_amounts: uint256[N_ALL_COINS], _is_deposit: bool) -> uint256:
     """
     @notice Calculate addition or reduction in token supply from a deposit or withdrawal
     @dev This calculation accounts for slippage, but not fees.
          Needed to prevent front-running, not for precise calculations!
-    @param amounts Amount of each underlying coin being deposited
-    @param is_deposit set True for deposits, False for withdrawals
+    @param _amounts Amount of each underlying coin being deposited
+    @param _is_deposit set True for deposits, False for withdrawals
     @return Expected amount of LP tokens received
     """
     meta_amounts: uint256[N_COINS] = empty(uint256[N_COINS])
     base_amounts: uint256[BASE_N_COINS] = empty(uint256[BASE_N_COINS])
 
     for i in range(MAX_COIN):
-        meta_amounts[i] = amounts[i]
+        meta_amounts[i] = _amounts[i]
 
     for i in range(BASE_N_COINS):
-        base_amounts[i] = amounts[i + MAX_COIN]
+        base_amounts[i] = _amounts[i + MAX_COIN]
 
-    _base_tokens: uint256 = CurveBase(self.base_pool).calc_token_amount(base_amounts, is_deposit)
-    meta_amounts[MAX_COIN] = _base_tokens
+    base_tokens: uint256 = CurveBase(self.base_pool).calc_token_amount(base_amounts, _is_deposit)
+    meta_amounts[MAX_COIN] = base_tokens
 
-    return CurveMeta(self.pool).calc_token_amount(meta_amounts, is_deposit)
+    return CurveMeta(self.pool).calc_token_amount(meta_amounts, _is_deposit)

--- a/contracts/pool-templates/meta/SwapTemplateMeta.vy
+++ b/contracts/pool-templates/meta/SwapTemplateMeta.vy
@@ -373,16 +373,13 @@ def add_liquidity(_amounts: uint256[N_COINS], _min_mint_amount: uint256) -> uint
 
     amp: uint256 = self._A()
     vp_rate: uint256 = self._vp_rate()
-    lp_token: address = self.lp_token
-    token_supply: uint256 = CurveToken(lp_token).totalSupply()
-    fee: uint256 = self.fee * N_COINS / (4 * (N_COINS - 1))
-    admin_fee: uint256 = self.admin_fee
+    old_balances: uint256[N_COINS] = self.balances
 
     # Initial invariant
-    D0: uint256 = 0
-    old_balances: uint256[N_COINS] = self.balances
-    if token_supply > 0:
-        D0 = self._get_D_mem(vp_rate, old_balances, amp)
+    D0: uint256 = self._get_D_mem(vp_rate, old_balances, amp)
+    
+    lp_token: address = self.lp_token
+    token_supply: uint256 = CurveToken(lp_token).totalSupply()
     new_balances: uint256[N_COINS] = old_balances
 
     for i in range(N_COINS):
@@ -401,6 +398,8 @@ def add_liquidity(_amounts: uint256[N_COINS], _min_mint_amount: uint256) -> uint
     D2: uint256 = D1
     mint_amount: uint256 = 0
     if token_supply > 0:
+        fee: uint256 = self.fee * N_COINS / (4 * (N_COINS - 1))
+        admin_fee: uint256 = self.admin_fee
         # Only account for fees if we are not the first to deposit
         for i in range(N_COINS):
             ideal_balance: uint256 = D1 * old_balances[i] / D0
@@ -822,10 +821,6 @@ def remove_liquidity_imbalance(_amounts: uint256[N_COINS], _max_burn_amount: uin
         new_balances[i] -= _amounts[i]
     D1: uint256 = self._get_D_mem(vp_rate, new_balances, amp)
 
-    lp_token: address = self.lp_token
-    token_supply: uint256 = CurveToken(lp_token).totalSupply()
-    assert token_supply != 0  # dev: zero total supply
-
     fee: uint256 = self.fee * N_COINS / (4 * (N_COINS - 1))
     admin_fee: uint256 = self.admin_fee
     fees: uint256[N_COINS] = empty(uint256[N_COINS])
@@ -841,6 +836,8 @@ def remove_liquidity_imbalance(_amounts: uint256[N_COINS], _max_burn_amount: uin
         new_balances[i] -= fees[i]
     D2: uint256 = self._get_D_mem(vp_rate, new_balances, amp)
 
+    lp_token: address = self.lp_token
+    token_supply: uint256 = CurveToken(lp_token).totalSupply()
     token_amount: uint256 = (D0 - D2) * token_supply / D0
     assert token_amount != 0  # dev: zero tokens burned
     token_amount += 1  # In case of rounding errors - make it unfavorable for the "attacker"

--- a/contracts/pool-templates/meta/SwapTemplateMeta.vy
+++ b/contracts/pool-templates/meta/SwapTemplateMeta.vy
@@ -277,7 +277,7 @@ def _vp_rate_ro() -> uint256:
 
 @pure
 @internal
-def get_D(_xp: uint256[N_COINS], _amp: uint256) -> uint256:
+def _get_D(_xp: uint256[N_COINS], _amp: uint256) -> uint256:
     S: uint256 = 0
     Dprev: uint256 = 0
 
@@ -308,8 +308,8 @@ def get_D(_xp: uint256[N_COINS], _amp: uint256) -> uint256:
 
 @view
 @internal
-def get_D_mem(_vp_rate: uint256, _balances: uint256[N_COINS], _amp: uint256) -> uint256:
-    return self.get_D(self._xp_mem(_vp_rate, _balances), _amp)
+def _get_D_mem(_vp_rate: uint256, _balances: uint256[N_COINS], _amp: uint256) -> uint256:
+    return self._get_D(self._xp_mem(_vp_rate, _balances), _amp)
 
 
 @view
@@ -323,7 +323,7 @@ def get_virtual_price() -> uint256:
     amp: uint256 = self._A()
     vp_rate: uint256 = self._vp_rate_ro()
     xp: uint256[N_COINS] = self._xp(vp_rate)
-    D: uint256 = self.get_D(xp, amp)
+    D: uint256 = self._get_D(xp, amp)
     # D is in the units similar to DAI (e.g. converted to precision 1e18)
     # When balanced, D = n * x_u - total virtual value of the portfolio
     token_supply: uint256 = CurveToken(self.lp_token).totalSupply()
@@ -344,13 +344,13 @@ def calc_token_amount(_amounts: uint256[N_COINS], _is_deposit: bool) -> uint256:
     amp: uint256 = self._A()
     vp_rate: uint256 = self._vp_rate_ro()
     balances: uint256[N_COINS] = self.balances
-    D0: uint256 = self.get_D_mem(vp_rate, balances, amp)
+    D0: uint256 = self._get_D_mem(vp_rate, balances, amp)
     for i in range(N_COINS):
         if _is_deposit:
             balances[i] += _amounts[i]
         else:
             balances[i] -= _amounts[i]
-    D1: uint256 = self.get_D_mem(vp_rate, balances, amp)
+    D1: uint256 = self._get_D_mem(vp_rate, balances, amp)
     token_amount: uint256 = CurveToken(self.lp_token).totalSupply()
     diff: uint256 = 0
     if _is_deposit:
@@ -382,7 +382,7 @@ def add_liquidity(_amounts: uint256[N_COINS], _min_mint_amount: uint256) -> uint
     D0: uint256 = 0
     old_balances: uint256[N_COINS] = self.balances
     if token_supply > 0:
-        D0 = self.get_D_mem(vp_rate, old_balances, amp)
+        D0 = self._get_D_mem(vp_rate, old_balances, amp)
     new_balances: uint256[N_COINS] = old_balances
 
     for i in range(N_COINS):
@@ -392,7 +392,7 @@ def add_liquidity(_amounts: uint256[N_COINS], _min_mint_amount: uint256) -> uint
         new_balances[i] = old_balances[i] + _amounts[i]
 
     # Invariant after change
-    D1: uint256 = self.get_D_mem(vp_rate, new_balances, amp)
+    D1: uint256 = self._get_D_mem(vp_rate, new_balances, amp)
     assert D1 > D0
 
     # We need to recalculate the invariant accounting for fees
@@ -412,7 +412,7 @@ def add_liquidity(_amounts: uint256[N_COINS], _min_mint_amount: uint256) -> uint
             fees[i] = fee * difference / FEE_DENOMINATOR
             self.balances[i] = new_balances[i] - (fees[i] * admin_fee / FEE_DENOMINATOR)
             new_balances[i] -= fees[i]
-        D2 = self.get_D_mem(vp_rate, new_balances, amp)
+        D2 = self._get_D_mem(vp_rate, new_balances, amp)
         mint_amount = token_supply * (D2 - D0) / D0
     else:
         self.balances = new_balances
@@ -448,7 +448,7 @@ def add_liquidity(_amounts: uint256[N_COINS], _min_mint_amount: uint256) -> uint
 
 @view
 @internal
-def get_y(i: int128, j: int128, x: uint256, _xp: uint256[N_COINS]) -> uint256:
+def _get_y(i: int128, j: int128, x: uint256, _xp: uint256[N_COINS]) -> uint256:
     # x in the input is converted to the same price/precision
 
     assert i != j       # dev: same coin
@@ -460,7 +460,7 @@ def get_y(i: int128, j: int128, x: uint256, _xp: uint256[N_COINS]) -> uint256:
     assert i < N_COINS
 
     A: uint256 = self._A()
-    D: uint256 = self.get_D(_xp, A)
+    D: uint256 = self._get_D(_xp, A)
     Ann: uint256 = A * N_COINS
     c: uint256 = D
     S: uint256 = 0
@@ -501,7 +501,7 @@ def get_dy(i: int128, j: int128, _dx: uint256) -> uint256:
     xp: uint256[N_COINS] = self._xp(rates[MAX_COIN])
 
     x: uint256 = xp[i] + _dx * rates[i] / PRECISION
-    y: uint256 = self.get_y(i, j, x, xp)
+    y: uint256 = self._get_y(i, j, x, xp)
     dy: uint256 = xp[j] - y - 1
     fee: uint256 = self.fee * dy / FEE_DENOMINATOR
     return (dy - fee) * PRECISION / rates[j]
@@ -546,7 +546,7 @@ def get_dy_underlying(i: int128, j: int128, _dx: uint256) -> uint256:
             return Curve(base_pool).get_dy(base_i, base_j, _dx)
 
     # This pool is involved only when in-pool assets are used
-    y: uint256 = self.get_y(meta_i, meta_j, x, xp)
+    y: uint256 = self._get_y(meta_i, meta_j, x, xp)
     dy: uint256 = xp[meta_j] - y - 1
     dy = (dy - self.fee * dy / FEE_DENOMINATOR)
 
@@ -581,7 +581,7 @@ def exchange(i: int128, j: int128, _dx: uint256, _min_dy: uint256) -> uint256:
     xp: uint256[N_COINS] = self._xp_mem(rates[MAX_COIN], old_balances)
 
     x: uint256 = xp[i] + _dx * rates[i] / PRECISION
-    y: uint256 = self.get_y(i, j, x, xp)
+    y: uint256 = self._get_y(i, j, x, xp)
 
     dy: uint256 = xp[j] - y - 1  # -1 just in case there were some rounding errors
     dy_fee: uint256 = dy * self.fee / FEE_DENOMINATOR
@@ -717,7 +717,7 @@ def exchange_underlying(i: int128, j: int128, _dx: uint256, _min_dy: uint256) ->
             # Adding number of pool tokens
             x += xp[MAX_COIN]
 
-        y: uint256 = self.get_y(meta_i, meta_j, x, xp)
+        y: uint256 = self._get_y(meta_i, meta_j, x, xp)
 
         # Either a real coin or token
         dy = xp[meta_j] - y - 1  # -1 just in case there were some rounding errors
@@ -813,10 +813,10 @@ def remove_liquidity_imbalance(_amounts: uint256[N_COINS], _max_burn_amount: uin
     vp_rate: uint256 = self._vp_rate()
     old_balances: uint256[N_COINS] = self.balances
     new_balances: uint256[N_COINS] = old_balances
-    D0: uint256 = self.get_D_mem(vp_rate, old_balances, amp)
+    D0: uint256 = self._get_D_mem(vp_rate, old_balances, amp)
     for i in range(N_COINS):
         new_balances[i] -= _amounts[i]
-    D1: uint256 = self.get_D_mem(vp_rate, new_balances, amp)
+    D1: uint256 = self._get_D_mem(vp_rate, new_balances, amp)
 
     lp_token: address = self.lp_token
     token_supply: uint256 = CurveToken(lp_token).totalSupply()
@@ -835,7 +835,7 @@ def remove_liquidity_imbalance(_amounts: uint256[N_COINS], _max_burn_amount: uin
         fees[i] = fee * difference / FEE_DENOMINATOR
         self.balances[i] = new_balances[i] - (fees[i] * admin_fee / FEE_DENOMINATOR)
         new_balances[i] -= fees[i]
-    D2: uint256 = self.get_D_mem(vp_rate, new_balances, amp)
+    D2: uint256 = self._get_D_mem(vp_rate, new_balances, amp)
 
     token_amount: uint256 = (D0 - D2) * token_supply / D0
     assert token_amount != 0  # dev: zero tokens burned
@@ -854,7 +854,7 @@ def remove_liquidity_imbalance(_amounts: uint256[N_COINS], _max_burn_amount: uin
 
 @pure
 @internal
-def get_y_D(A: uint256, i: int128, _xp: uint256[N_COINS], D: uint256) -> uint256:
+def _get_y_D(A: uint256, i: int128, _xp: uint256[N_COINS], D: uint256) -> uint256:
     """
     Calculate x[i] if one reduces D from being calculated for xp to D
 
@@ -907,11 +907,11 @@ def _calc_withdraw_one_coin(_token_amount: uint256, i: int128, _vp_rate: uint256
     # * Solve Eqn against y_i for D - _token_amount
     amp: uint256 = self._A()
     xp: uint256[N_COINS] = self._xp(_vp_rate)
-    D0: uint256 = self.get_D(xp, amp)
+    D0: uint256 = self._get_D(xp, amp)
 
     total_supply: uint256 = CurveToken(self.lp_token).totalSupply()
     D1: uint256 = D0 - _token_amount * D0 / total_supply
-    new_y: uint256 = self.get_y_D(amp, i, xp, D1)
+    new_y: uint256 = self._get_y_D(amp, i, xp, D1)
 
     fee: uint256 = self.fee * N_COINS / (4 * (N_COINS - 1))
     rates: uint256[N_COINS] = RATES
@@ -928,7 +928,7 @@ def _calc_withdraw_one_coin(_token_amount: uint256, i: int128, _vp_rate: uint256
             dx_expected = xp[j] - xp[j] * D1 / D0
         xp_reduced[j] -= fee * dx_expected / FEE_DENOMINATOR
 
-    dy: uint256 = xp_reduced[i] - self.get_y_D(amp, i, xp_reduced, D1)
+    dy: uint256 = xp_reduced[i] - self._get_y_D(amp, i, xp_reduced, D1)
     dy = (dy - 1) * PRECISION / rates[i]  # Withdraw less to account for rounding errors
 
     return dy, dy_0 - dy, total_supply

--- a/contracts/pool-templates/y/DepositTemplateY.vy
+++ b/contracts/pool-templates/y/DepositTemplateY.vy
@@ -49,7 +49,7 @@ def __init__(
     _coins: address[N_COINS],
     _underlying_coins: address[N_COINS],
     _curve: address,
-    _lp_token: address
+    _token: address
 ):
     """
     @notice Contract constructor
@@ -58,7 +58,7 @@ def __init__(
     @param _coins List of wrapped coin addresses
     @param _underlying_coins List of underlying coin addresses
     @param _curve Pool address
-    @param _lp_token Pool LP token address
+    @param _token Pool LP token address
     """
     for i in range(N_COINS):
         assert _coins[i] != ZERO_ADDRESS
@@ -91,7 +91,7 @@ def __init__(
     self.coins = _coins
     self.underlying_coins = _underlying_coins
     self.curve = _curve
-    self.lp_token = _lp_token
+    self.lp_token = _token
 
 
 @external

--- a/contracts/pool-templates/y/DepositTemplateY.vy
+++ b/contracts/pool-templates/y/DepositTemplateY.vy
@@ -41,7 +41,7 @@ FEE_IMPRECISION: constant(uint256) = 25 * 10 ** 8  # % of the fee
 coins: public(address[N_COINS])
 underlying_coins: public(address[N_COINS])
 curve: public(address)
-token: public(address)
+lp_token: public(address)
 
 
 @external
@@ -49,7 +49,7 @@ def __init__(
     _coins: address[N_COINS],
     _underlying_coins: address[N_COINS],
     _curve: address,
-    _token: address
+    _lp_token: address
 ):
     """
     @notice Contract constructor
@@ -58,7 +58,7 @@ def __init__(
     @param _coins List of wrapped coin addresses
     @param _underlying_coins List of underlying coin addresses
     @param _curve Pool address
-    @param _token Pool LP token address
+    @param _lp_token Pool LP token address
     """
     for i in range(N_COINS):
         assert _coins[i] != ZERO_ADDRESS
@@ -91,7 +91,7 @@ def __init__(
     self.coins = _coins
     self.underlying_coins = _underlying_coins
     self.curve = _curve
-    self.token = _token
+    self.lp_token = _lp_token
 
 
 @external
@@ -104,12 +104,12 @@ def add_liquidity(_underlying_amounts: uint256[N_COINS], _min_mint_amount: uint2
     @return Amount of LP tokens received by depositing
     """
     use_lending: bool[N_COINS] = USE_LENDING
-    _wrapped_amounts: uint256[N_COINS] = empty(uint256[N_COINS])
+    wrapped_amounts: uint256[N_COINS] = empty(uint256[N_COINS])
 
     for i in range(N_COINS):
-        _amount: uint256 = _underlying_amounts[i]
+        amount: uint256 = _underlying_amounts[i]
 
-        if _amount != 0:
+        if amount != 0:
             # Transfer the underlying coin from owner
             _response: Bytes[32] = raw_call(
                 self.underlying_coins[i],
@@ -117,7 +117,7 @@ def add_liquidity(_underlying_amounts: uint256[N_COINS], _min_mint_amount: uint2
                     method_id("transferFrom(address,address,uint256)"),
                     convert(msg.sender, bytes32),
                     convert(self, bytes32),
-                    convert(_amount, bytes32)
+                    convert(amount, bytes32)
                 ),
                 max_outsize=32
             )
@@ -126,19 +126,19 @@ def add_liquidity(_underlying_amounts: uint256[N_COINS], _min_mint_amount: uint2
 
             # Mint if needed
             if use_lending[i]:
-                _coin: address = self.coins[i]
-                yERC20(_coin).deposit(_amount)
-                _wrapped_amounts[i] = ERC20(_coin).balanceOf(self)
+                coin: address = self.coins[i]
+                yERC20(coin).deposit(amount)
+                wrapped_amounts[i] = ERC20(coin).balanceOf(self)
             else:
-                _wrapped_amounts[i] = _amount
+                wrapped_amounts[i] = amount
 
-    Curve(self.curve).add_liquidity(_wrapped_amounts, _min_mint_amount)
+    Curve(self.curve).add_liquidity(wrapped_amounts, _min_mint_amount)
 
-    _lp_token: address = self.token
-    _lp_amount: uint256 = ERC20(_lp_token).balanceOf(self)
-    assert ERC20(_lp_token).transfer(msg.sender, _lp_amount)
+    lp_token: address = self.lp_token
+    lp_amount: uint256 = ERC20(lp_token).balanceOf(self)
+    assert ERC20(lp_token).transfer(msg.sender, lp_amount)
 
-    return _lp_amount
+    return lp_amount
 
 
 @internal
@@ -189,7 +189,7 @@ def remove_liquidity(
     @param _min_underlying_amounts Minimum amounts of underlying coins to receive
     @return List of amounts of underlying coins that were withdrawn
     """
-    assert ERC20(self.token).transferFrom(msg.sender, self, _amount)
+    assert ERC20(self.lp_token).transferFrom(msg.sender, self, _amount)
     Curve(self.curve).remove_liquidity(_amount, empty(uint256[N_COINS]))
 
     return self._unwrap_and_transfer(msg.sender, _min_underlying_amounts)
@@ -210,7 +210,7 @@ def remove_liquidity_imbalance(
     @return List of amounts of underlying coins that were withdrawn
     """
     use_lending: bool[N_COINS] = USE_LENDING
-    _token: address = self.token
+    lp_token: address = self.lp_token
 
     amounts: uint256[N_COINS] = _underlying_amounts
     for i in range(N_COINS):
@@ -221,17 +221,17 @@ def remove_liquidity_imbalance(
         # if not use_lending - all good already
 
     # Transfer max tokens in
-    _lp_amount: uint256 = ERC20(_token).balanceOf(msg.sender)
+    _lp_amount: uint256 = ERC20(lp_token).balanceOf(msg.sender)
     if _lp_amount > _max_burn_amount:
         _lp_amount = _max_burn_amount
-    assert ERC20(_token).transferFrom(msg.sender, self, _lp_amount)
+    assert ERC20(lp_token).transferFrom(msg.sender, self, _lp_amount)
 
     Curve(self.curve).remove_liquidity_imbalance(amounts, _max_burn_amount)
 
     # Transfer unused LP tokens back
-    _lp_amount = ERC20(_token).balanceOf(self)
+    _lp_amount = ERC20(lp_token).balanceOf(self)
     if _lp_amount != 0:
-        assert ERC20(_token).transfer(msg.sender, _lp_amount)
+        assert ERC20(lp_token).transfer(msg.sender, _lp_amount)
 
     # Unwrap and transfer all the coins we've got
     return self._unwrap_and_transfer(msg.sender, empty(uint256[N_COINS]))
@@ -251,22 +251,22 @@ def remove_liquidity_one_coin(
     @param _min_underlying_amount Minimum amount of underlying coin to receive
     @return Amount of underlying coin received
     """
-    assert ERC20(self.token).transferFrom(msg.sender, self, _amount)
+    assert ERC20(self.lp_token).transferFrom(msg.sender, self, _amount)
 
     Curve(self.curve).remove_liquidity_one_coin(_amount, i, 0)
 
     use_lending: bool[N_COINS] = USE_LENDING
     if use_lending[i]:
-        _coin: address = self.coins[i]
-        _balance: uint256 = ERC20(_coin).balanceOf(self)
-        yERC20(_coin).withdraw(_balance)
+        coin: address = self.coins[i]
+        _balance: uint256 = ERC20(coin).balanceOf(self)
+        yERC20(coin).withdraw(_balance)
 
-    _coin: address = self.underlying_coins[i]
-    _balance: uint256 = ERC20(_coin).balanceOf(self)
+    coin: address = self.underlying_coins[i]
+    _balance: uint256 = ERC20(coin).balanceOf(self)
     assert _balance >= _min_underlying_amount, "Not enough coins removed"
 
     _response: Bytes[32] = raw_call(
-        _coin,
+        coin,
         concat(
             method_id("transfer(address,uint256)"),
             convert(msg.sender, bytes32),

--- a/tests/fixtures/deployments.py
+++ b/tests/fixtures/deployments.py
@@ -115,7 +115,7 @@ def zap(project, alice, swap, underlying_coins, wrapped_coins, pool_token, pool_
 
 @pytest.fixture(scope="module")
 def aave_lending_pool(AaveLendingPoolMock, pool_data, alice, is_forked):
-    if pool_data['name'] == "aave" or pool_data['name'] == "template-a":
+    if pool_data["name"] == "aave" or pool_data["name"] == "template-a":
         if is_forked:
             return Contract("0x7d2768dE32b0b80b7a3454c06BdAc94A69DDc7A9")
         else:

--- a/tests/fixtures/deployments.py
+++ b/tests/fixtures/deployments.py
@@ -115,7 +115,7 @@ def zap(project, alice, swap, underlying_coins, wrapped_coins, pool_token, pool_
 
 @pytest.fixture(scope="module")
 def aave_lending_pool(AaveLendingPoolMock, pool_data, alice, is_forked):
-    if pool_data["name"] in ("aave", "saave"):
+    if pool_data['name'] == "aave" or pool_data['name'] == "template-a":
         if is_forked:
             return Contract("0x7d2768dE32b0b80b7a3454c06BdAc94A69DDc7A9")
         else:

--- a/tests/fixtures/deployments.py
+++ b/tests/fixtures/deployments.py
@@ -115,7 +115,7 @@ def zap(project, alice, swap, underlying_coins, wrapped_coins, pool_token, pool_
 
 @pytest.fixture(scope="module")
 def aave_lending_pool(AaveLendingPoolMock, pool_data, alice, is_forked):
-    if pool_data["name"] == "aave" or pool_data["name"] == "template-a":
+    if pool_data["name"] in ("aave", "template-a"):
         if is_forked:
             return Contract("0x7d2768dE32b0b80b7a3454c06BdAc94A69DDc7A9")
         else:

--- a/tests/fixtures/deployments.py
+++ b/tests/fixtures/deployments.py
@@ -115,7 +115,7 @@ def zap(project, alice, swap, underlying_coins, wrapped_coins, pool_token, pool_
 
 @pytest.fixture(scope="module")
 def aave_lending_pool(AaveLendingPoolMock, pool_data, alice, is_forked):
-    if pool_data["name"] in ("aave", "template-a"):
+    if pool_data["name"] in ("aave", "saave", "template-a"):
         if is_forked:
             return Contract("0x7d2768dE32b0b80b7a3454c06BdAc94A69DDc7A9")
         else:

--- a/tests/pools/common/integration/test_curve.py
+++ b/tests/pools/common/integration/test_curve.py
@@ -4,10 +4,12 @@ from itertools import permutations
 import pytest
 from brownie.test import given, strategy
 from hypothesis import settings
-
 from simulation import Curve
 
-pytestmark = [pytest.mark.skip_meta, pytest.mark.skip_pool("aave", "seth", "steth", "template-a")]
+pytestmark = [
+    pytest.mark.skip_meta,
+    pytest.mark.skip_pool("aave", "seth", "steth", "template-a", "template-eth"),
+]
 
 
 @given(

--- a/tests/pools/common/integration/test_curve.py
+++ b/tests/pools/common/integration/test_curve.py
@@ -7,7 +7,7 @@ from hypothesis import settings
 
 from simulation import Curve
 
-pytestmark = [pytest.mark.skip_meta, pytest.mark.skip_pool("aave", "aeth", "saave", "seth", "steth")]
+pytestmark = [pytest.mark.skip_meta, pytest.mark.skip_pool("aave", "seth", "steth", "template-a")]
 
 
 @given(

--- a/tests/pools/common/integration/test_curve.py
+++ b/tests/pools/common/integration/test_curve.py
@@ -8,7 +8,7 @@ from simulation import Curve
 
 pytestmark = [
     pytest.mark.skip_meta,
-    pytest.mark.skip_pool("aave", "seth", "steth", "template-a", "template-eth"),
+    pytest.mark.skip_pool("aave", "saave", "seth", "steth", "template-eth", "template-a"),
 ]
 
 

--- a/tests/pools/common/integration/test_curve.py
+++ b/tests/pools/common/integration/test_curve.py
@@ -4,6 +4,7 @@ from itertools import permutations
 import pytest
 from brownie.test import given, strategy
 from hypothesis import settings
+
 from simulation import Curve
 
 pytestmark = [

--- a/tests/pools/common/integration/test_curve.py
+++ b/tests/pools/common/integration/test_curve.py
@@ -8,7 +8,7 @@ from simulation import Curve
 
 pytestmark = [
     pytest.mark.skip_meta,
-    pytest.mark.skip_pool("aave", "saave", "seth", "steth", "template-eth", "template-a"),
+    pytest.mark.skip_pool("aave", "saave", "aeth", "seth", "steth", "template-eth", "template-a"),
 ]
 
 

--- a/tests/pools/common/integration/test_simulate_exchange.py
+++ b/tests/pools/common/integration/test_simulate_exchange.py
@@ -5,7 +5,7 @@ from hypothesis import settings
 from simulation import Curve
 
 # do not run this test on pools without lending or meta pools
-pytestmark = [pytest.mark.lending, pytest.mark.skip_meta, pytest.mark.skip_pool("aave", "saave")]
+pytestmark = [pytest.mark.lending, pytest.mark.skip_meta, pytest.mark.skip_pool("aave", "template-a")]
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/pools/common/integration/test_simulate_exchange.py
+++ b/tests/pools/common/integration/test_simulate_exchange.py
@@ -7,7 +7,7 @@ from simulation import Curve
 pytestmark = [
     pytest.mark.lending,
     pytest.mark.skip_meta,
-    pytest.mark.skip_pool("aave", "template-a"),
+    pytest.mark.skip_pool("aave", "saave", "template-a"),
 ]
 
 

--- a/tests/pools/common/integration/test_simulate_exchange.py
+++ b/tests/pools/common/integration/test_simulate_exchange.py
@@ -1,11 +1,14 @@
 import pytest
 from brownie.test import given, strategy
 from hypothesis import settings
-
 from simulation import Curve
 
 # do not run this test on pools without lending or meta pools
-pytestmark = [pytest.mark.lending, pytest.mark.skip_meta, pytest.mark.skip_pool("aave", "template-a")]
+pytestmark = [
+    pytest.mark.lending,
+    pytest.mark.skip_meta,
+    pytest.mark.skip_pool("aave", "template-a"),
+]
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/pools/common/integration/test_simulate_exchange.py
+++ b/tests/pools/common/integration/test_simulate_exchange.py
@@ -1,6 +1,7 @@
 import pytest
 from brownie.test import given, strategy
 from hypothesis import settings
+
 from simulation import Curve
 
 # do not run this test on pools without lending or meta pools

--- a/tests/pools/common/unitary/test_modify_fees.py
+++ b/tests/pools/common/unitary/test_modify_fees.py
@@ -5,7 +5,7 @@ COMMIT_WAIT = 86400 * 3
 MAX_ADMIN_FEE = 5 * 10 ** 9
 MAX_FEE = 5 * 10 ** 9
 
-pytestmark = pytest.mark.skip_pool("aave", "saave","busd", "compound", "susd", "usdt", "y")
+pytestmark = pytest.mark.skip_pool("aave", "busd", "compound", "susd", "usdt", "y", "template-a")
 
 
 @pytest.mark.parametrize(

--- a/tests/pools/common/unitary/test_modify_fees.py
+++ b/tests/pools/common/unitary/test_modify_fees.py
@@ -5,7 +5,9 @@ COMMIT_WAIT = 86400 * 3
 MAX_ADMIN_FEE = 5 * 10 ** 9
 MAX_FEE = 5 * 10 ** 9
 
-pytestmark = pytest.mark.skip_pool("aave", "busd", "compound", "susd", "usdt", "y", "template-a")
+pytestmark = pytest.mark.skip_pool(
+    "aave", "busd", "saave", "compound", "susd", "usdt", "y", "template-a"
+)
 
 
 @pytest.mark.parametrize(

--- a/tests/pools/common/unitary/test_remove_liquidity_one_coin.py
+++ b/tests/pools/common/unitary/test_remove_liquidity_one_coin.py
@@ -10,7 +10,7 @@ pytestmark = [
 
 @pytest.mark.itercoins("idx")
 @pytest.mark.parametrize("rate_mod", [0.9, 0.99, 1.01, 1.1])
-@pytest.mark.skip_pool("ren", "sbtc", "aave", "steth", "template-a")
+@pytest.mark.skip_pool("ren", "sbtc", "aave", "steth", "aeth", "template-a")
 def test_amount_received(chain, alice, swap, wrapped_coins, wrapped_decimals, idx, rate_mod):
 
     decimals = wrapped_decimals[idx]

--- a/tests/pools/common/unitary/test_remove_liquidity_one_coin.py
+++ b/tests/pools/common/unitary/test_remove_liquidity_one_coin.py
@@ -10,7 +10,7 @@ pytestmark = [
 
 @pytest.mark.itercoins("idx")
 @pytest.mark.parametrize("rate_mod", [0.9, 0.99, 1.01, 1.1])
-@pytest.mark.skip_pool("ren", "sbtc", "aave", "steth", "saave", "aeth")
+@pytest.mark.skip_pool("ren", "sbtc", "aave", "steth", "template-a")
 def test_amount_received(chain, alice, swap, wrapped_coins, wrapped_decimals, idx, rate_mod):
 
     decimals = wrapped_decimals[idx]

--- a/tests/pools/common/unitary/test_remove_liquidity_one_coin.py
+++ b/tests/pools/common/unitary/test_remove_liquidity_one_coin.py
@@ -10,7 +10,7 @@ pytestmark = [
 
 @pytest.mark.itercoins("idx")
 @pytest.mark.parametrize("rate_mod", [0.9, 0.99, 1.01, 1.1])
-@pytest.mark.skip_pool("ren", "sbtc", "aave", "steth", "aeth", "template-a")
+@pytest.mark.skip_pool("ren", "sbtc", "aave", "saave", "steth", "aeth", "template-a")
 def test_amount_received(chain, alice, swap, wrapped_coins, wrapped_decimals, idx, rate_mod):
 
     decimals = wrapped_decimals[idx]

--- a/tests/pools/common/unitary/test_xfer_to_contract.py
+++ b/tests/pools/common/unitary/test_xfer_to_contract.py
@@ -29,7 +29,7 @@ def __init__(swap: address):
         assert sum(get_admin_balances()) == 0
 
 
-@pytest.mark.skip_pool("aave", "steth", "saave",reason="Aave-style interest accrues by increasing balance")
+@pytest.mark.skip_pool("aave", "steth", "template-a", reason="Aave-style interest accrues by increasing balance")
 def test_unexpected_coin(swap, alice, bob, get_admin_balances, wrapped_coins):
     virtual_price = swap.get_virtual_price()
 

--- a/tests/pools/common/unitary/test_xfer_to_contract.py
+++ b/tests/pools/common/unitary/test_xfer_to_contract.py
@@ -29,7 +29,9 @@ def __init__(swap: address):
         assert sum(get_admin_balances()) == 0
 
 
-@pytest.mark.skip_pool("aave", "steth", "template-a", reason="Aave-style interest accrues by increasing balance")
+@pytest.mark.skip_pool(
+    "aave", "steth", "template-a", reason="Aave-style interest accrues by increasing balance"
+)
 def test_unexpected_coin(swap, alice, bob, get_admin_balances, wrapped_coins):
     virtual_price = swap.get_virtual_price()
 

--- a/tests/pools/common/unitary/test_xfer_to_contract.py
+++ b/tests/pools/common/unitary/test_xfer_to_contract.py
@@ -30,7 +30,11 @@ def __init__(swap: address):
 
 
 @pytest.mark.skip_pool(
-    "aave", "steth", "template-a", reason="Aave-style interest accrues by increasing balance"
+    "aave",
+    "steth",
+    "saave",
+    "template-a",
+    reason="Aave-style interest accrues by increasing balance",
 )
 def test_unexpected_coin(swap, alice, bob, get_admin_balances, wrapped_coins):
     virtual_price = swap.get_virtual_price()


### PR DESCRIPTION
### What I did

Added new pool templates and brushed over the current pool templates to ensure that there is a higher level of consistency between these.

#### New Pool Templates
* Add pool template for `aToken`-style pools
* Add pool template for `ETH` pools

#### Style
* Follow the internal [Curve Vyper style guide](https://github.com/curvefi/contributor-guides/blob/main/Vyper-Style-Guide.md) and ensure pool templates are consistent with it
* Ensure pool templates are consistent with each other (where possible, e.g. var names, function visibility, events. 

#### Tests
* Minimal changes to `fixtures/deplyments.py` and individual tests to support `template-a` tests.

*Note*: The templates for `a` and `y` are still quite Aave and Yearn specific, respectively. However, it should be quite trivial for the implementer to make the required changes and remove any unwanted protocol-specific logic. 

### How to verify it

Run unit tests for each template:

Example: `brownie test tests/pools/ --pool template-base --unitary`
