### PR TITLE
Test pool methods with insufficient balances

### DIFF
--- a/contracts/testing/cERC20.vy
+++ b/contracts/testing/cERC20.vy
@@ -76,7 +76,7 @@ def transfer(_to : address, _value : uint256) -> bool:
 
 @external
 def transferFrom(_from : address, _to : address, _value : uint256) -> bool:
-    if self.balanceOf[msg.sender] < _value or self.allowances[_from][msg.sender] < _value:
+    if self.balanceOf[_from] < _value or self.allowances[_from][msg.sender] < _value:
         return False
     self.balanceOf[_from] -= _value
     self.balanceOf[_to] += _value

--- a/tests/pools/common/integration/test_curve.py
+++ b/tests/pools/common/integration/test_curve.py
@@ -7,7 +7,10 @@ from hypothesis import settings
 
 from simulation import Curve
 
-pytestmark = [pytest.mark.skip_meta, pytest.mark.skip_pool("aave", "aeth", "saave", "seth", "steth")]
+pytestmark = [
+    pytest.mark.skip_meta,
+    pytest.mark.skip_pool("aave", "aeth", "saave", "seth", "steth"),
+]
 
 
 @given(

--- a/tests/pools/common/unitary/test_modify_fees.py
+++ b/tests/pools/common/unitary/test_modify_fees.py
@@ -5,7 +5,7 @@ COMMIT_WAIT = 86400 * 3
 MAX_ADMIN_FEE = 5 * 10 ** 9
 MAX_FEE = 5 * 10 ** 9
 
-pytestmark = pytest.mark.skip_pool("aave", "saave","busd", "compound", "susd", "usdt", "y")
+pytestmark = pytest.mark.skip_pool("aave", "saave", "busd", "compound", "susd", "usdt", "y")
 
 
 @pytest.mark.parametrize(

--- a/tests/pools/common/unitary/test_xfer_to_contract.py
+++ b/tests/pools/common/unitary/test_xfer_to_contract.py
@@ -29,7 +29,9 @@ def __init__(swap: address):
         assert sum(get_admin_balances()) == 0
 
 
-@pytest.mark.skip_pool("aave", "steth", "saave",reason="Aave-style interest accrues by increasing balance")
+@pytest.mark.skip_pool(
+    "aave", "steth", "saave", reason="Aave-style interest accrues by increasing balance"
+)
 def test_unexpected_coin(swap, alice, bob, get_admin_balances, wrapped_coins):
     virtual_price = swap.get_virtual_price()
 

--- a/tests/test_insufficient_balances.py
+++ b/tests/test_insufficient_balances.py
@@ -1,0 +1,66 @@
+import itertools
+
+import brownie
+import pytest
+from brownie import ETH_ADDRESS
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup(mint_alice, approve_alice, mint_bob, approve_bob, set_fees):
+    set_fees(4000000, 5000000000, include_meta=True)
+
+
+def test_add_liquidity_insufficient_balance(
+    chain,
+    alice,
+    bob,
+    charlie,
+    swap,
+    n_coins,
+    wrapped_decimals,
+    underlying_decimals,
+    wrapped_coins,
+    underlying_coins,
+    initial_amounts,
+):
+    # attempt to deposit 10x more funds than user has
+    amounts = [i * 10 for i in initial_amounts]
+    value = initial_amounts[0] if ETH_ADDRESS in wrapped_coins else 0
+    with brownie.reverts():
+        swap.add_liquidity(amounts, 0, {"from": alice, "value": value})
+
+    # add liquidity balanced
+    amounts = [i // 2 for i in initial_amounts]
+    value = amounts[0] if ETH_ADDRESS in wrapped_coins else 0
+    swap.add_liquidity(amounts, 0, {"from": alice, "value": value})
+
+    # attempt to perform swaps between coins with insufficient funds
+    for send, recv in itertools.permutations(range(n_coins), 2):
+        amount = initial_amounts[send] // 4
+        value = 0 if wrapped_coins[send] != ETH_ADDRESS else amount
+        if underlying_coins[send] == ETH_ADDRESS:
+            continue
+        with brownie.reverts():
+            swap.exchange(send, recv, amount, 0, {"from": charlie, "value": value})
+
+    # attempt to perform swaps between coins with insufficient funds
+    if hasattr(swap, "exchange_underlying"):
+        for send, recv in itertools.permutations(range(n_coins), 2):
+            assert underlying_coins[send].balanceOf(charlie) == 0
+            amount = initial_amounts[send] // 4
+            with brownie.reverts():
+                swap.exchange_underlying(send, recv, amount, 0, {"from": charlie})
+
+    # remove liquidity
+    with brownie.reverts():
+        swap.remove_liquidity(10 ** 18, [0] * n_coins, {"from": charlie})
+    chain.sleep(3600)
+
+    # remove liquidity imbalance
+    if hasattr(swap, "remove_liquidity_one_coin"):
+        for idx in range(n_coins):
+            with brownie.reverts():
+                swap.remove_liquidity_one_coin(
+                    10 ** wrapped_decimals[idx], idx, 0, {"from": charlie}
+                )
+            chain.sleep(3600)

--- a/tests/test_insufficient_balances.py
+++ b/tests/test_insufficient_balances.py
@@ -54,7 +54,6 @@ def test_add_liquidity_insufficient_balance(
     # remove liquidity
     with brownie.reverts():
         swap.remove_liquidity(10 ** 18, [0] * n_coins, {"from": charlie})
-    chain.sleep(3600)
 
     # remove liquidity imbalance
     if hasattr(swap, "remove_liquidity_one_coin"):
@@ -63,4 +62,3 @@ def test_add_liquidity_insufficient_balance(
                 swap.remove_liquidity_one_coin(
                     10 ** wrapped_decimals[idx], idx, 0, {"from": charlie}
                 )
-            chain.sleep(3600)


### PR DESCRIPTION
### What I did

Add a test similar to `test_gas.py` but expecting reverts due to insufficient funds by the sender. This should catch unexpected ERC20 returns (e.g. minting LP tokens for free, faulty swapping). 

### How to verify it
Should pass: `brownie test tests/test_insufficient_balances.py --pool compound`

Should fail: `brownie test tests/test_insufficient_balances.py --pool yv2`