### PR TITLE
Standardize templates

### DIFF
--- a/contracts/pool-templates/base/SwapTemplateBase.vy
+++ b/contracts/pool-templates/base/SwapTemplateBase.vy
@@ -307,7 +307,7 @@ def add_liquidity(_amounts: uint256[N_COINS], _min_mint_amount: uint256) -> uint
 
     # Initial invariant
     D0: uint256 = self._get_D_mem(old_balances, amp)
-    
+
     lp_token: address = self.lp_token
     token_supply: uint256 = CurveToken(lp_token).totalSupply()
     new_balances: uint256[N_COINS] = old_balances
@@ -521,7 +521,6 @@ def remove_liquidity(_amount: uint256, _min_amounts: uint256[N_COINS]) -> uint25
     lp_token: address = self.lp_token
     total_supply: uint256 = CurveToken(lp_token).totalSupply()
     amounts: uint256[N_COINS] = empty(uint256[N_COINS])
-    fees: uint256[N_COINS] = empty(uint256[N_COINS])  # Fees are unused but we've got them historically in event
 
     for i in range(N_COINS):
         old_balance: uint256 = self.balances[i]
@@ -543,7 +542,7 @@ def remove_liquidity(_amount: uint256, _min_amounts: uint256[N_COINS]) -> uint25
 
     CurveToken(lp_token).burnFrom(msg.sender, _amount)  # dev: insufficient funds
 
-    log RemoveLiquidity(msg.sender, amounts, fees, total_supply - _amount)
+    log RemoveLiquidity(msg.sender, amounts, empty(uint256[N_COINS]), total_supply - _amount)
 
     return amounts
 


### PR DESCRIPTION
### What i did
- in `remove_liquidity`, use `empty` within the event rather than defining a memory variable
- avoid multiple `response` mem vars within the metapool template
- declare `input_coin` and `output_coin` sequentially

All of these are minor gas optimizations.