### PR TITLE
Integrate brownie-token-tester; bump versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,14 +3,14 @@ repos:
     rev: 19.3b0
     hooks:
     -   id: black
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.4
     hooks:
     -   id: flake8
--   repo: https://github.com/pre-commit/mirrors-isort
-    rev: v4.3.21
+-   repo: https://github.com/PyCQA/isort
+    rev: 5.7.0
     hooks:
-    -    id: isort
+    -   id: isort
 
     default_language_version:
         python: python3.8

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Curve allows users to trade between correlated cryptocurrencies with a bespoke l
 * [python3](https://www.python.org/downloads/release/python-368/) from version 3.6 to 3.8, python3-dev
 * [brownie](https://github.com/iamdefinitelyahuman/brownie) - tested with version [1.13.0](https://github.com/eth-brownie/brownie/releases/tag/v1.13.0)
 * [ganache-cli](https://github.com/trufflesuite/ganache-cli) - tested with version [6.12.1](https://github.com/trufflesuite/ganache-cli/releases/tag/v6.12.1)
+* [brownie-token-tester](https://github.com/iamdefinitelyahuman/brownie-token-tester) - tested with version [0.1.0](https://github.com/iamdefinitelyahuman/brownie-token-tester/releases/tag/v0.1.0)
 
 Curve contracts are compiled using [Vyper](https://github.com/vyperlang/vyper), however installation of the required Vyper versions is handled by Brownie.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 black==19.10b0
 eth-brownie>=1.13.0,<2.0.0
-flake8==3.7.9
-isort==4.3.21
+flake8==3.8.4
+isort==5.7.0
+brownie-token-tester>=0.1.0

--- a/tests/fixtures/coins.py
+++ b/tests/fixtures/coins.py
@@ -1,12 +1,7 @@
 import pytest
-import requests
-from brownie import ETH_ADDRESS, ZERO_ADDRESS, Contract, ERC20Mock, ERC20MockNoReturn
-from brownie.convert import to_address
-
+from brownie import ETH_ADDRESS, ZERO_ADDRESS, ERC20Mock, ERC20MockNoReturn
+from brownie_tokens import MintableForkToken
 from conftest import WRAPPED_COIN_METHODS
-
-_holders = {}
-
 
 # public fixtures - these can be used when testing
 
@@ -49,7 +44,7 @@ def base_pool_token(project, charlie, base_pool_data, is_forked):
 # private API below
 
 
-class _MintableTestToken(Contract):
+class _MintableTestToken(MintableForkToken):
     def __init__(self, address, pool_data=None):
         super().__init__(address)
 
@@ -59,61 +54,6 @@ class _MintableTestToken(Contract):
             for target, attr in fn_names.items():
                 if hasattr(self, attr) and target != attr:
                     setattr(self, target, getattr(self, attr))
-
-        # get top token holder addresses
-        address = self.address
-        if address not in _holders:
-            holders = requests.get(
-                f"https://api.ethplorer.io/getTopTokenHolders/{address}",
-                params={"apiKey": "freekey", "limit": 50},
-            ).json()
-            _holders[address] = [to_address(i["address"]) for i in holders["holders"]]
-
-    def _mint_for_testing(self, target, amount, tx=None):
-        if self.address == "0x674C6Ad92Fd080e4004b2312b45f796a192D27a0":
-            # USDN
-            self.deposit(target, amount, {"from": "0x90f85042533F11b362769ea9beE20334584Dcd7D"})
-            return
-        if self.address == "0x0E2EC54fC0B509F445631Bf4b91AB8168230C752":
-            # LinkUSD
-            self.mint(target, amount, {"from": "0x62F31E08e279f3091d9755a09914DF97554eAe0b"})
-            return
-        if self.address == "0x196f4727526eA7FB1e17b2071B3d8eAA38486988":
-            # RSV
-            self.changeMaxSupply(2 ** 128, {"from": self.owner()})
-            self.mint(target, amount, {"from": self.minter()})
-            return
-        if self.address == "0x5228a22e72ccC52d415EcFd199F99D0665E7733b":
-            # pBTC
-            self.mint(target, amount, {"from": self.pNetwork()})
-            return
-        if self.name().startswith("Aave"):
-            underlying = _MintableTestToken(self.UNDERLYING_ASSET_ADDRESS())
-            lending_pool = Contract("0x7d2768dE32b0b80b7a3454c06BdAc94A69DDc7A9")
-
-            underlying._mint_for_testing(target, amount)
-            underlying.approve(lending_pool, amount, {"from": target})
-            lending_pool.deposit(underlying, amount, target, 0, {"from": target})
-            return
-
-        for address in _holders[self.address].copy():
-            if address == self.address:
-                # don't claim from the treasury - that could cause wierdness
-                continue
-
-            balance = self.balanceOf(address)
-            try:
-                if amount > balance:
-                    self.transfer(target, balance, {"from": address})
-                    amount -= balance
-                else:
-                    self.transfer(target, amount, {"from": address})
-                    return
-            except Exception:
-                # sometimes tokens just don't want to be stolen
-                pass
-
-        raise ValueError(f"Insufficient tokens available to mint {self.name()}")
 
 
 def _deploy_wrapped(project, alice, pool_data, idx, underlying, aave_lending_pool):

--- a/tests/pools/aave/integration/test_curve_aave.py
+++ b/tests/pools/aave/integration/test_curve_aave.py
@@ -4,7 +4,6 @@ from itertools import permutations
 import pytest
 from brownie.test import given, strategy
 from hypothesis import settings
-
 from simulation import Curve
 
 pytestmark = pytest.mark.skip_meta

--- a/tests/pools/aave/integration/test_simulate_exchange_aave.py
+++ b/tests/pools/aave/integration/test_simulate_exchange_aave.py
@@ -1,7 +1,6 @@
 import pytest
 from brownie.test import given, strategy
 from hypothesis import settings
-
 from simulation import Curve
 
 # do not run this test on pools without lending or meta pools

--- a/tests/pools/common/integration/test_curve.py
+++ b/tests/pools/common/integration/test_curve.py
@@ -4,7 +4,6 @@ from itertools import permutations
 import pytest
 from brownie.test import given, strategy
 from hypothesis import settings
-
 from simulation import Curve
 
 pytestmark = [

--- a/tests/pools/common/integration/test_simulate_exchange.py
+++ b/tests/pools/common/integration/test_simulate_exchange.py
@@ -1,7 +1,6 @@
 import pytest
 from brownie.test import given, strategy
 from hypothesis import settings
-
 from simulation import Curve
 
 # do not run this test on pools without lending or meta pools


### PR DESCRIPTION
## What did I do?

* Integrated [`brownie-token-tester`](https://github.com/iamdefinitelyahuman/brownie-token-tester) to handle custom ERC20 minting logic in fork tests
* Bumped `isort` (no longer has the `unknown_third_party` issues) and `flake8`
