### PR TITLE
fix: ib pooldata.json lp_token_address string

### DIFF
--- a/contracts/pools/ib/pooldata.json
+++ b/contracts/pools/ib/pooldata.json
@@ -3,7 +3,7 @@
     "pool_types": ["crate"],
     "wrapped_contract": "cERC20",
     "swap_address": "0x2dded6Da1BF5DBdF597C45fcFaa3194e53EcfeAF",
-    "lp_token_address": "0x5282a4eF67D9C33135340fB3289cc1711c13638C ",
+    "lp_token_address": "0x5282a4eF67D9C33135340fB3289cc1711c13638C",
     "gauge_addresses": ["0xF5194c3325202F456c95c1Cf0cA36f8475C1949F"],
     "lp_constructor": {
         "symbol": "ib3CRV",


### PR DESCRIPTION
Extremely minor fix, I removed some whitespace at end of a string. Found this out because it messes with the registry deployment process. The pooldata.json file is pretty standardized so there shouldn't be any whitespace in the strings anyways. 
