### PR TITLE
Add aETH rate calculator contract

### DIFF
--- a/contracts/pool-templates/README.md
+++ b/contracts/pool-templates/README.md
@@ -45,7 +45,10 @@ The layout of a template's `pooldata.json` is similar to that of an actual pool,
             "wrapped_decimals": 18,  // decimal places for the wrapped coin - can be omitted if wrapped == false
         },
     ]
+    "rate_calculator_address": ""    // address of exchange rate calculator for pools with unique logic
 }
 ```
 
 _Note_: For `y` and `a` pools, the implementor may have to remove/change some small parts in the template code which is specific to `yearn` and `aave` pools.
+
+The `rate_calcultor_address` is used when adding a pool to the Curve Pool Registry.

--- a/contracts/pool-templates/eth/RateCalculatorTemplateETH.vy
+++ b/contracts/pool-templates/eth/RateCalculatorTemplateETH.vy
@@ -1,0 +1,15 @@
+# @version 0.2.11
+"""
+@title Curve Pool Rate Calculator 
+@author Curve.Fi
+@license Copyright (c) Curve.Fi, 2021 - all rights reserved
+@notice Logic for calculating exchange rate for a pool
+@dev This contract is only a template, pool-specific logic
+    must be added
+"""
+
+
+@view
+@external
+def get_rate(_coin: address) -> uint256:
+    return 0

--- a/contracts/pool-templates/meta/RateCalculatorTemplateMeta.vy
+++ b/contracts/pool-templates/meta/RateCalculatorTemplateMeta.vy
@@ -1,0 +1,15 @@
+# @version 0.2.11
+"""
+@title Curve Pool Rate Calculator 
+@author Curve.Fi
+@license Copyright (c) Curve.Fi, 2021 - all rights reserved
+@notice Logic for calculating exchange rate for a pool
+@dev This contract is only a template, pool-specific logic
+    must be added
+"""
+
+
+@view
+@external
+def get_rate(_coin: address) -> uint256:
+    return 0

--- a/contracts/pools/README.md
+++ b/contracts/pools/README.md
@@ -46,6 +46,8 @@ Each subdirectory holds contracts and other files specific to a single Curve poo
 {
     "lp_contract": "CurveTokenV1",       // LP token contract to use with this pool, from `contracts/tokens`
     "wrapped_contract": "yERC20",        // mock wrapped coin contract to use, from `contracts/testing`
+    // optional
+    "rate_calculator_address": ""        // address of exchange rate calculator for with unique pool logic
 
     // constructor settings for the LP token - required for deployment
     "lp_constructor": {

--- a/contracts/pools/aeth/RateCalculatorAETH.vy
+++ b/contracts/pools/aeth/RateCalculatorAETH.vy
@@ -1,0 +1,24 @@
+# @version 0.2.11
+"""
+@title Curve Pool Rate Calculator 
+@author Curve.Fi
+@license Copyright (c) Curve.Fi, 2021 - all rights reserved
+@notice Logic for calculating exchange rate for a pool
+@dev This contract is only a template, pool-specific logic
+    must be added
+"""
+
+interface aETH:
+    def ratio() -> uint256: view
+
+
+@view
+@external
+def get_rate(_coin: address) -> uint256:
+    """
+    @notice Calculate the exchange rate for 1 aETH -> ETH
+    @param _coin The aETH contract address
+    @return The exchange rate of 1 aETH in ETH
+    """
+    result: uint256 = aETH(_coin).ratio()
+    return 10 ** 36 / result

--- a/contracts/pools/aeth/RateCalculatorAETH.vy
+++ b/contracts/pools/aeth/RateCalculatorAETH.vy
@@ -1,11 +1,9 @@
 # @version 0.2.11
 """
-@title Curve Pool Rate Calculator 
+@title Curve aETH Pool Rate Calculator 
 @author Curve.Fi
 @license Copyright (c) Curve.Fi, 2021 - all rights reserved
-@notice Logic for calculating exchange rate for a pool
-@dev This contract is only a template, pool-specific logic
-    must be added
+@notice Logic for calculating exchange rate between aETH -> ETH
 """
 
 interface aETH:

--- a/contracts/pools/aeth/pooldata.json
+++ b/contracts/pools/aeth/pooldata.json
@@ -32,5 +32,5 @@
   "testing": {
     "initial_amount": 10000
   },
-  "rate_calculator_address": ""
+  "rate_calculator_address": "0x1B0D3406F49ED85ACb907F0554e787dEB6cEac33"
 }

--- a/contracts/pools/aeth/pooldata.json
+++ b/contracts/pools/aeth/pooldata.json
@@ -31,5 +31,6 @@
   ],
   "testing": {
     "initial_amount": 10000
-  }
+  },
+  "rate_calculator_address": ""
 }

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -95,4 +95,12 @@ def main():
 
         zap_deployer.deploy(*deployment_args)
 
+    # deploy the rate calculator
+    rate_calc_name = next(
+        (i.stem for i in contracts_path.glob(f"{POOL_NAME}/RateCalculator*")), None
+    )
+    if rate_calc_name is not None:
+        rate_calc_deployer = getattr(project, rate_calc_name)
+        rate_calc_deployer.deploy(_tx_params())
+
     print(f"Gas used in deployment: {(balance - DEPLOYER.balance()) / 1e18:.4f} ETH")


### PR DESCRIPTION
### What I did

Ahead of curvefi/curve-pool-registry#19, I've made a couple additions. Specifically this PR accounts for aETH related adjustments.

- Added template rate calculator for pools
- Added the aETH exchange rate calculator which conforms to the expected ABI for the new registry update
- Added to the deploy script to deploy the rate calculator of a given pool (this way rate_calculator deployment is handled at deploy time)
- Updated the respective READMEs

### How I did it

Used my l33t haX0r ski11zzz

### How to verify it

Not really much to verify but I guess you could try deploying a pool in forked-mainnet mode for fun
