### PR TITLE
fix: compiler version and `convert` usage in temps

### DIFF
--- a/contracts/pool-templates/meta/DepositTemplateMeta.vy
+++ b/contracts/pool-templates/meta/DepositTemplateMeta.vy
@@ -1,4 +1,4 @@
-# @version ^0.2.8
+# @version ^0.2.12
 """
 @title "Zap" Depositer for metapool
 @author Curve.Fi
@@ -65,7 +65,7 @@ def __init__(_pool: address, _token: address):
     self.base_pool = base_pool
 
     for i in range(N_COINS):
-        coin: address = CurveMeta(_pool).coins(convert(i, uint256))
+        coin: address = CurveMeta(_pool).coins(i)
         self.coins[i] = coin
         # approve coins for infinite transfers
         _response: Bytes[32] = raw_call(

--- a/contracts/pool-templates/meta/SwapTemplateMeta.vy
+++ b/contracts/pool-templates/meta/SwapTemplateMeta.vy
@@ -1,4 +1,4 @@
-# @version ^0.2.8
+# @version ^0.2.12
 """
 @title StableSwap
 @author Curve.Fi
@@ -184,7 +184,7 @@ def __init__(
     self.base_virtual_price = Curve(_base_pool).get_virtual_price()
     self.base_cache_updated = block.timestamp
     for i in range(BASE_N_COINS):
-        base_coin: address = Curve(_base_pool).coins(convert(i, uint256))
+        base_coin: address = Curve(_base_pool).coins(i)
         self.base_coins[i] = base_coin
 
         # approve underlying coins for infinite transfers


### PR DESCRIPTION
### What I did

Fix compiler version and `convert` usage in templates which were causing CI failure.

Related issue: #131 

### How I tested

Ran the template-meta tests