### PR TITLE
Update deploy script to use new GaugeV3

### DIFF
--- a/brownie-config.yaml
+++ b/brownie-config.yaml
@@ -11,7 +11,7 @@ reports:
     - contracts/gauges/*.*
 
 dependencies:
-  - curvefi/curve-dao-contracts@1.1.0
+  - curvefi/curve-dao-contracts@1.2.0
 
 hypothesis:
   phases:

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -75,8 +75,8 @@ def main():
     token.set_minter(swap, _tx_params())
 
     # deploy the liquidity gauge
-    LiquidityGaugeV2 = load_project("curvefi/curve-dao-contracts@1.1.0").LiquidityGaugeV2
-    LiquidityGaugeV2.deploy(token, MINTER, GAUGE_OWNER, _tx_params())
+    LiquidityGaugeV3 = load_project("curvefi/curve-dao-contracts@1.2.0").LiquidityGaugeV3
+    LiquidityGaugeV3.deploy(token, MINTER, GAUGE_OWNER, _tx_params())
 
     # deploy the zap
     zap_name = next((i.stem for i in contracts_path.glob(f"{POOL_NAME}/Deposit*")), None)


### PR DESCRIPTION
### What I did

Minor update of the deploy script to use the newest gauge version, LiquidityGaugeV3, for new deployments. 

Related issue: curvefi/curve-dao-contracts#100

### How I did it

find and replace mainly

### How to verify it

With one of the new pools, try a dummy deployment in mainnet-fork. I tested using the `aave` pool and passed
