### PR TITLE
Missing an item from the formula

### DIFF
--- a/contracts/pool-templates/base/SwapTemplateBase.vy
+++ b/contracts/pool-templates/base/SwapTemplateBase.vy
@@ -211,7 +211,7 @@ def _get_D(_xp: uint256[N_COINS], _amp: uint256) -> uint256:
     A * sum(x_i) * n**n + D = A * D * n**n + D**(n+1) / (n**n * prod(x_i))
 
     Converging solution:
-    D[j+1] = (A * n**n * sum(x_i) - D[j]**(n+1) / (n**n prod(x_i))) / (A * n**n - 1)
+    D[j+1] = (A * n**n * sum(x_i) - D[j]**(n+1) / (n**n prod(x_i))) / (A * n**n + (n+1)*D[j]**n/(n**n prod(x_i)) - 1)
     """
     S: uint256 = 0
     Dprev: uint256 = 0


### PR DESCRIPTION
<!-- Opening a new pool? Add `&template=pool.md` to the current URL to use the new pool PR template -->

### What I did

Fixed a mistake in code comments. Missing an item from the formula.

### How I did it

Modify code comments with adding an item in formula.

```python
+ (n+1)*D[j]**n/(n**n prod(x_i)
```

### How to verify it

the correct newton's method formula is

<img src="https://render.githubusercontent.com/render/math?math=D_{new}=\frac{An^n\sum x_i-\frac{D^{n%2B1}}{n^n\prod x_i}}{An^n%2B(n%2B1)\frac{D^n}{n^n\prod x_i}-1}" />
 
There is an missing item in origin code comments.

<img src="https://render.githubusercontent.com/render/math?math=(n%2B1)\frac{D^n}{n^n\prod x_i}" />
