### PR TITLE
Fix misleading _A argument description

### DIFF
--- a/contracts/pool-templates/base/SwapTemplateBase.vy
+++ b/contracts/pool-templates/base/SwapTemplateBase.vy
@@ -133,7 +133,7 @@ def __init__(
     @param _owner Contract owner address
     @param _coins Addresses of ERC20 conracts of coins
     @param _pool_token Address of the token representing LP share
-    @param _A Amplification coefficient multiplied by n * (n - 1)
+    @param _A Amplification coefficient multiplied by n ** (n - 1)
     @param _fee Fee to charge for exchanges
     @param _admin_fee Admin fee
     """


### PR DESCRIPTION
Current description of _A does not comply to invariant math used in contract. Typo is present in multiple pool contracts, I'm pushing this as an example fix.

### What I did
Fixed one of the present typos which provide misleading interpretation of _A argument.
This fix as an example of how this description should be adapted through the codebase, as it is widely present.

Related issue: #
_A argument should be described as "amplification coefficient multiplied by n ** (n-1)"
instead of "amplification coefficient multiplied by n * (n-1)".
(the diff is only one "*")

### How I did it
I reviewed the Ann computation and concluded that for `A = ac * n * (n-1)`, `A * n != Ann`
but for `A = ac * n ** (n-1)`, `A * n == Ann`
// ac == amplification coefficient

### How to verify it
Check Ann computation within pools that are based on stable-swap invariant
