### PR TITLE
Corrected typos

### DIFF
--- a/contracts/pool-templates/README.md
+++ b/contracts/pool-templates/README.md
@@ -49,6 +49,6 @@ The layout of a template's `pooldata.json` is similar to that of an actual pool,
 }
 ```
 
-_Note_: For `y` and `a` pools, the implementor may have to remove/change some small parts in the template code which is specific to `yearn` and `aave` pools.
+_Note_: For `y` and `a` pools, the implementer may have to remove/change some small parts in the template code which is specific to `yearn` and `aave` pools.
 
 The `rate_calcultor_address` is used when adding a pool to the Curve Pool Registry.

--- a/contracts/tokens/README.md
+++ b/contracts/tokens/README.md
@@ -4,8 +4,8 @@
 
 ## Contracts
 
-* [`CurveTokenV1`](CurveTokenV1.vy): LP token targetting Vyper [`^0.1.0-beta.16`](https://vyper.readthedocs.io/en/stable/release-notes.html#v0-1-0-beta-16)
-* [`CurveTokenV2`](CurveTokenV2.vy): LP token targetting Vyper [`^0.2.0`](https://vyper.readthedocs.io/en/stable/release-notes.html#v0-2-1)
+* [`CurveTokenV1`](CurveTokenV1.vy): LP token targeting Vyper [`^0.1.0-beta.16`](https://vyper.readthedocs.io/en/stable/release-notes.html#v0-1-0-beta-16)
+* [`CurveTokenV2`](CurveTokenV2.vy): LP token targeting Vyper [`^0.2.0`](https://vyper.readthedocs.io/en/stable/release-notes.html#v0-2-1)
 
 ## Development
 

--- a/integrations.md
+++ b/integrations.md
@@ -5,7 +5,7 @@ First of all, you'll need to know the contract's
 Addresses of the contract and the token representing liquidity are
 [here](https://github.com/curvefi/curve-contract/blob/compounded/deployed/2020-01-21_mainnet/mainnet.log).
 
-Next is the breif description of methods you need to fascilitate exchanges.
+Next is the brief description of methods you need to fascilitate exchanges.
 
 ## Getting static information
 


### PR DESCRIPTION
Changes made in:

- /integrations.md ("breif" → "brief")

- /contracts/pool-templates/README.md ("implementor" → "implementer")

- /contracts/tokens/README.md ("targetting" → "targeting")

- /contracts/tokens/README.md ("targetting" → "targeting")
